### PR TITLE
`fasterRaster` 8.3.0.7014

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ As of 2024/05/17, a new version of this package, `fasterRaster 8.3`, is in alpha
 
 # Getting started
 
-To install **fasterRaster**, please use:
+To install `fasterRaster`, please use:
 
 `remotes::install_github('adamlilith/fasterRaster', dependencies = TRUE)`  
 
@@ -191,7 +191,7 @@ Key: <value>
 10:    10        pit   104 0.0012
 ```
 
-To complete the comparison, we'll graph their relative frequencies using **ggplot2** (not required by **fasterRaster**).
+To complete the comparison, we'll graph their relative frequencies using `ggplot2` (not required by `fasterRaster`).
 ```
 library(ggplot2)
 
@@ -245,7 +245,7 @@ To see a detailed list of functions available in `fasterRaster`, attach the pack
 
 4. By default, `fasterRaster` use 2 cores and 1024 MB (1 GB) of memory for `GRASS` modules that allow users to specify these values. You can set these to higher values using `faster()` and thus potentially speed up some calculations. Functions in newer versions of `GRASS` have more capacity to use these options, so updating `GRASS` to the latest version can help, too.
 
-5. Compared to **terra** and **sf**, **fasterRaster** is *not* faster with vectors, so if you can, do vector processing with those packages first.
+5. Compared to `terra` and `sf`, `fasterRaster` is *not* faster with vectors, so if you can, do vector processing with those packages first.
 
 # Versioning
 


### PR DESCRIPTION
# fasterRaster 8.3.0.7014 (2024-05-17)

## Functionality
o Added function `flow()` for calculating flow of water across a landscape.
o Added function `flowPath()` for calculating flow of water from specific points on a landscape.
o `freq()` inserts category labels into results for for categorical `GRaster`s
o Added function `geomorphons()` for identifying geomorphological features.
o Added function `maskNA()` for converting non-`NA` cells or `NA` cells to a user-defined value.
o `plot()` displays of levels of categorical rasters.
o Can save layer-by-layer with `writeRaster()`.
o Added ability to create `points` `GVector`s from numeric, matrices, or data frames using `fast()`
o Improved auto-assessment of raster `datatype` in `writeRaster()`.
o Updated `README` for 8.3.0.7013!

## Bug fixes
o `[` works consistently for `GVector`s!!!!!
o Hidden function `.makeGVector()` now catches cases with zero extent for polygons.
o Fixed installation issue related to `activeCat()<-` and `addCats()<-` (thank you, `@kbondo1`!)
o Fixed bug in `arithmetic` when determining data type of an input raster.
o `crds()` works when the **GRASS** vector has an attribute table.
o `extract()` extracts values from `GVector`s for large numbers of points without crashing
o `plot()` works! (Previous issue arose from changing output of `writeRaster()` to `GRaster`).
o `rast()` correctly returns a `SpatRaster`.
o `vect()` correctly returns a `SpatVector`.

## Issues
o Removed `rasterPrecision` option and now use internal function `.getPrec()` to ascertain the proper precision of rasters.
o Option to fail in creation of `GRaster` or a `polygons` `GVector` if it would have a zero extent.

## Changes
o `complete.cases()` and `missing.cases()` return logical vectors for vectors with no data tables (was integer vectors).
