### PR TITLE
`fasterRaster` 8.3.0.7014

### DIFF
--- a/R/tutorial_getting_started.r
+++ b/R/tutorial_getting_started.r
@@ -97,7 +97,6 @@
 #' To convert a `GVector` to the **terra** package's `SpatVector` format or to an `sf` vector, use [vect()] or [st_as_sf()]:
 #' ```
 #' terraRivers <- vect(rivers)
-#' sfRivers <- st_as_sf(rivers)
 #' ```
 #'
 #' Finally, you can use [writeRaster()] and [writeVector()] to save **fasterRaster** rasters and vectors directly to disk. This will always be faster than using [rast()], [vect()], or [st_as_sf()] then saving.
@@ -106,20 +105,20 @@
 #' writeRaster(elev, elevTempFile)
 #'
 #' vectTempFile <- tempfile(fileext = ".shp") # save as shapefile
-#' writeRaster(rivers, vectTempFile)
+#' writeVector(rivers, vectTempFile)
 #' ```
 #'
 #' ## Tips for masking **fasterRaster** faster
 #'
 #' 1. Loading rasters and vectors directly from disk using [fast()], rather than converting **terra** or **sf** objects is faster. Why? Because if the object does not have a file to which the **R** object points, `fast()` has to save it to disk first as a GeoTIFF or GeoPackage file, then load it into **GRASS**.
 #'
-#' 2. Similarly, saving `GRaster`s and `GVector`s directly to disk will always be faster than converting them to `SpatRaster`s, `SpatVector`s, or `sf` vectors using [rast()], [vect()], or [st_as_sf()], then saving them. Why? Because these functions actually save the file to disk then uses the respective function from the respective package to connect to the file.
+#' 2. Similarly, saving `GRaster`s and `GVector`s directly to disk will always be faster than converting them to `SpatRaster`s or `SpatVector`susing [rast()] or [vect()], then saving them. Why? Because these functions actually save the file to disk then uses the respective function from the respective package to connect to the file.
 #'
 #' 3. Every time you switch between using a `GRaster` or `GVector` with a different coordinate reference system (CRS), **GRASS** has to spend a few second changing to that CRS. So, you can save some time by doing as much work as possible with objects in one CRS, then switching to work on objects in another CRS.
 #'
 #' 4. By default, **GRASS**/**fasterRaster** use 2 cores and 1024 MB (1 GB) of memory for functions that allow users to specify these values. You can set these to higher values using [faster()] and thus potentially speed up some calculations. Functions in newer versions of **GRASS** have more capacity to use these options, so updating **GRASS** to the latest version can help, too.
 #'
-#' 5. Unfortunately, **fasterRaster** is fast with rasters, but not so much vectors. The \code{\link[fasterRaster]{[[}} is especially slow for even moderately-sized vectors. If you have plan on making subsets of subsets, it is advisable to do your subsetting on the index that will be used to subset the vector first, then do just a single subset.
+#' 5. Unfortunately, **fasterRaster** is fast with rasters, but not so much vectors. If you have a lot of vector operations, it is advisable to do as much as possible in **terra** or **sf** and transfer to **fasterRaster** when needed.
 #'
 #' ## Further reading
 #' 

--- a/man/tutorial_getting_started.Rd
+++ b/man/tutorial_getting_started.Rd
@@ -106,7 +106,6 @@ You can convert a \code{GRaster} to a \code{SpatRaster} raster using \code{\link
 To convert a \code{GVector} to the \strong{terra} package's \code{SpatVector} format or to an \code{sf} vector, use \code{\link[=vect]{vect()}} or \code{\link[=st_as_sf]{st_as_sf()}}:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{terraRivers <- vect(rivers)
-sfRivers <- st_as_sf(rivers)
 }\if{html}{\out{</div>}}
 
 Finally, you can use \code{\link[=writeRaster]{writeRaster()}} and \code{\link[=writeVector]{writeVector()}} to save \strong{fasterRaster} rasters and vectors directly to disk. This will always be faster than using \code{\link[=rast]{rast()}}, \code{\link[=vect]{vect()}}, or \code{\link[=st_as_sf]{st_as_sf()}} then saving.
@@ -115,17 +114,17 @@ Finally, you can use \code{\link[=writeRaster]{writeRaster()}} and \code{\link[=
 writeRaster(elev, elevTempFile)
 
 vectTempFile <- tempfile(fileext = ".shp") # save as shapefile
-writeRaster(rivers, vectTempFile)
+writeVector(rivers, vectTempFile)
 }\if{html}{\out{</div>}}
 }
 
 \subsection{Tips for masking \strong{fasterRaster} faster}{
 \enumerate{
 \item Loading rasters and vectors directly from disk using \code{\link[=fast]{fast()}}, rather than converting \strong{terra} or \strong{sf} objects is faster. Why? Because if the object does not have a file to which the \strong{R} object points, \code{fast()} has to save it to disk first as a GeoTIFF or GeoPackage file, then load it into \strong{GRASS}.
-\item Similarly, saving \code{GRaster}s and \code{GVector}s directly to disk will always be faster than converting them to \code{SpatRaster}s, \code{SpatVector}s, or \code{sf} vectors using \code{\link[=rast]{rast()}}, \code{\link[=vect]{vect()}}, or \code{\link[=st_as_sf]{st_as_sf()}}, then saving them. Why? Because these functions actually save the file to disk then uses the respective function from the respective package to connect to the file.
+\item Similarly, saving \code{GRaster}s and \code{GVector}s directly to disk will always be faster than converting them to \code{SpatRaster}s or \code{SpatVector}susing \code{\link[=rast]{rast()}} or \code{\link[=vect]{vect()}}, then saving them. Why? Because these functions actually save the file to disk then uses the respective function from the respective package to connect to the file.
 \item Every time you switch between using a \code{GRaster} or \code{GVector} with a different coordinate reference system (CRS), \strong{GRASS} has to spend a few second changing to that CRS. So, you can save some time by doing as much work as possible with objects in one CRS, then switching to work on objects in another CRS.
 \item By default, \strong{GRASS}/\strong{fasterRaster} use 2 cores and 1024 MB (1 GB) of memory for functions that allow users to specify these values. You can set these to higher values using \code{\link[=faster]{faster()}} and thus potentially speed up some calculations. Functions in newer versions of \strong{GRASS} have more capacity to use these options, so updating \strong{GRASS} to the latest version can help, too.
-\item Unfortunately, \strong{fasterRaster} is fast with rasters, but not so much vectors. The \code{\link[fasterRaster]{[[}} is especially slow for even moderately-sized vectors. If you have plan on making subsets of subsets, it is advisable to do your subsetting on the index that will be used to subset the vector first, then do just a single subset.
+\item Unfortunately, \strong{fasterRaster} is fast with rasters, but not so much vectors. If you have a lot of vector operations, it is advisable to do as much as possible in \strong{terra} or \strong{sf} and transfer to \strong{fasterRaster} when needed.
 }
 }
 


### PR DESCRIPTION
## Functionality
o Added function `flow()` for calculating flow of water across a landscape.
o Added function `flowPath()` for calculating flow of water from specific points on a landscape.
o `freq()` inserts category labels into results for for categorical `GRaster`s
o Added function `geomorphons()` for identifying geomorphological features.
o Added function `maskNA()` for converting non-`NA` cells or `NA` cells to a user-defined value.
o `plot()` displays of levels of categorical rasters.
o Can save layer-by-layer with `writeRaster()`.
o Added ability to create `points` `GVector`s from numeric, matrices, or data frames using `fast()`
o Improved auto-assessment of raster `datatype` in `writeRaster()`.
o Updated `README` for 8.3.0.7013!

## Bug fixes
o `[` works consistently for `GVector`s!!!!!
o Hidden function `.makeGVector()` now catches cases with zero extent for polygons.
o Fixed installation issue related to `activeCat()<-` and `addCats()<-` (thank you, `@kbondo1`!)
o Fixed bug in `arithmetic` when determining data type of an input raster.
o `crds()` works when the **GRASS** vector has an attribute table.
o `extract()` extracts values from `GVector`s for large numbers of points without crashing
o `plot()` works! (Previous issue arose from changing output of `writeRaster()` to `GRaster`).
o `rast()` correctly returns a `SpatRaster`.
o `vect()` correctly returns a `SpatVector`.

## Issues
o Removed `rasterPrecision` option and now use internal function `.getPrec()` to ascertain the proper precision of rasters.
o Option to fail in creation of `GRaster` or a `polygons` `GVector` if it would have a zero extent.

## Changes
o `complete.cases()` and `missing.cases()` return logical vectors for vectors with no data tables (was integer vectors).
