### PR TITLE
`8.3.0.7022`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ o Removed `sd()` and `sdpop()` and replaced with `stdev()`.
 
 ## Bug fixes and speed-ups
 o `atan2()` works!  
+o `extract()` extracts!    
 o `fast()` can convert a `SpatRaster` with one or more layers that are a subset of a larger `SpatRaster` into a `GRaster` without error.  
 o `fractalRast()` is faster.  
 o `freq()` work when the input is a categorical `GRaster`.  

--- a/R/extract.r
+++ b/R/extract.r
@@ -699,7 +699,7 @@ methods::setMethod(
     }
 
     # # don't know why, but having this here obviates extraction of all NAs on first extract attempt
-    # if (inherits(x, "GRaster")) plot(x); dev.off()
+    if (inherits(x, "GRaster")) x <- x + 0
 
     for (set in seq_len(sets)) {
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Faster raster processing in `R` using `GRASS GIS`
 `fasterRaster` makes heavy use of the <a href="https://cran.r-project.org/package=rgrass">`rgrass`</a> package by Roger Bivand and others, the <a href="https://cran.r-project.org/package=rgrass">`terra`</a> package by Robert Hijmans, the <a href="https://cran.r-project.org/package=sf">`sf`</a> package by Edzer Pebesma Roger Bivand, and of course <a href="https://grass.osgeo.org/">`GRASS GIS`</a>, so is greatly indebted to all of these creators!
 
 # Where we are
-As of 2024/08/01, a new version of this package, `fasterRaster 8.3`, is in alpha release (i.e., near final release). There are known issues and unknown issues. If you encounter one of the latter, please file an <a href="https://github.com/adamlilith/fasterRaster/issues">issue</a> report.
+As of 2024/09/01, a new version of this package, `fasterRaster 8.3`, is in alpha release (i.e., near final release). There are known issues and unknown issues. If you encounter one of the latter, please file an <a href="https://github.com/adamlilith/fasterRaster/issues">issue</a> report.
 
 **Special announcement**: The new `bioclims()` function creates the "classic" set of BIOCLIM variables, plus an optional "extended" set. The function works on **fasterRaster** `GRaster`s and on **terra** `SpatRaster`s!
 


### PR DESCRIPTION
## Main task of this re-release
o Examples in all help files have been checked and, if needed, either they or the calling function(s) have been fixed. See "Bug fixes and speed-ups" below.

## New functions and functionality
o `dim3d()` returns the "region's" dimensions when called with no arguments.  
o `global()` calculates quantiles much faster (minutes vs. weeks) for very large rasters.  
o `layerCor()` by default calculates inter-`GRaster` correlation.  
o `reorient()` converts facing angles between north and east orientations.  
o `terrain()` can return slope and aspect in radians, and allows a custom value to be set for undefined aspects.  
o Default value of `memory` in `faster()` is now 2 GB.

## Potentially co-breaking changes
o `global()` argument `prob` changed to `probs` because it can accommodate more than one value.  
o `horizonHeight()` function now uses argument `step` instead of `directions`.
o Removed `sd()` and `sdpop()` and replaced with `stdev()`.  

## Bug fixes and speed-ups
o `atan2()` works!  
o `extract()` extracts!    
o `fast()` can convert a `SpatRaster` with one or more layers that are a subset of a larger `SpatRaster` into a `GRaster` without error.  
o `fractalRast()` is faster.  
o `freq()` work when the input is a categorical `GRaster`.  
p `interpSplines()` bug causing lambda values to not be returned fixed.  
o `horizonHeight()` returns `GRaster`s that can be used directly in `sun()`.  
o `plotRGB()` is no longer stuck in an infinite loop an infinite loop an infinite loop an infinite loop an infinite loop an infinite loop an infinite loop.  
o `rSpatialDepRast()` is faster.  
o `replace_double_square_brackets` works!  
o `simplifyGeom()` works when using the "dp" or "dpr" methods.  
o `spatSample()` works when `byStratum = TRUE`.  
o `subset_dollar` bug fixed related to rationalization of `dim()` and `res()`.  
o `subset_double_square_brackets` works for `i = missing` and `j = ` not missing.  
o `subset_single_bracket` works for `x[i, j]` when neither `i` nor `j` are missing.  
o `sun()` works with `GRaster`s from `horizonHeight()`. 
o `terrain()` works when all methods (`v = '*'`) are called.  
o `update()` retains a `GVector`'s data table.  
o `vegIndex()` fixed bug parsing `index`.  
o `zonal()` works when zones are set by a `GVector`.  
