### PR TITLE
8.4.0.7028

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .Ruserdata
 docs
 \pkgdown
+\articles
 inst/doc
 junk
 /vignettes/junk

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fasterRaster
 Type: Package
 Title: Faster Raster and Spatial Vector Processing Using 'GRASS GIS'
-Version: 8.3.0.7027
-Date: 2024-10-15
+Version: 8.3.0.7028
+Date: 2024-10-24
 Authors@R: 
 	c(
 		person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: fasterRaster
 Type: Package
 Title: Faster Raster and Spatial Vector Processing Using 'GRASS GIS'
-Version: 8.3.0.7028
+Version: 8.4.0.7028
 Date: 2024-10-24
 Authors@R: 
 	c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# fasterRaster 8.4.0.7028 (2024-10-XX)
+# fasterRaster 8.4.0.7028 (2024-10-24)
 
 ### Main task
 o Clear for CRAN submission

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@ o `grassHelp()` can show the **GRASS** manual "table of contents" (argument `"to
 o `longlat()` can now return rasters with cell values equal to their coordinates in map units (previously, only coordinates in degrees were returned).  
 o For functions that are complicated or have extended references, added a note to the `@seealso` tag to see the respective **GRASS** manual page using `grassHelp()`.  
 
+### Bug and issue fixes
+o `project()` correctly restores the user's "location" to that of the newly projected `GRaster`.  
+
 # fasterRaster 8.4.0.7027 (2024-10-15)
 
 ### Main task for this version

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 o Clear for CRAN submission
 
 ### Enhanced functionality and new functions
+o `grassHelp()` can show the **GRASS** manual "table of contents" (argument `"toc"`).  
 o `longlat()` can now return rasters with cell values equal to their coordinates in map units (previously, only coordinates in degrees were returned).  
 o For functions that are complicated or have extended references, added a note to the `@seealso` tag to see the respective **GRASS** manual page using `grassHelp()`.  
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# fasterRaster 8.4.0.7028 (2024-10-XX)
+
+### Main task
+o Clear for CRAN submission
+
+### Enhanced functionality and new functions
+o `longlat()` can now return rasters with cell values equal to their coordinates in map units (previously, only coordinates in degrees were returned).  
+o For functions that are complicated or have extended references, added a note to the `@seealso` tag to see the respective **GRASS** manual page using `grassHelp()`.  
+
 # fasterRaster 8.4.0.7027 (2024-10-15)
 
 ### Main task for this version

--- a/R/01_generics.r
+++ b/R/01_generics.r
@@ -185,7 +185,7 @@ methods::setGeneric(name = "kurtosis", def = function(x, ...) standardGeneric("k
 # levels<- (in base) is primitive
 methods::setGeneric(name = "layerCor", package = "terra")
 methods::setGeneric(name = "ln", def = function(x, ...) standardGeneric("ln"))
-methods::setGeneric(name = "longlat", def = function(x) standardGeneric("longlat"))
+methods::setGeneric(name = "longlat", def = function(x, ...) standardGeneric("longlat"))
 methods::setGeneric(name = "log10p", def = function(x) standardGeneric("log10p"))
 
 methods::setGeneric(name = "mask", package = "terra")

--- a/R/07_comparison.r
+++ b/R/07_comparison.r
@@ -42,7 +42,7 @@ methods::setMethod(
 			name <- paste0(names(e1)[i], "_", names(e2)[i])
 			src <- .makeSourceName("comparison", "raster")
 
-			ex <- paste0(src, "= int(if(", sources(e1)[i], " ", oper, " ", sources(e2)[i], "))")
+			ex <- paste0(src, "= int(if(", sources(e1)[i], oper, sources(e2)[i], "))")
 			this <- .genericArithRast(name = name, src = src, ex = ex)
 			
 			if (i == 1L) {

--- a/R/addCats.r
+++ b/R/addCats.r
@@ -16,7 +16,7 @@
 #'
 #' @returns A `GRaster`. The "levels" table of the raster is modified.
 #'
-#' @seealso [terra::addCats()], [combineCats()], [combineLevels()], [droplevels()], `vignette("GRasters", package = "fasterRaster"`
+#' @seealso [terra::addCats()], [concats()], [combineLevels()], [droplevels()], `vignette("GRasters", package = "fasterRaster"`
 #'
 #' @example man/examples/ex_GRaster_categorical.r
 #'

--- a/R/app.r
+++ b/R/app.r
@@ -42,7 +42,7 @@
 #'
 #' @returns A `GRaster`.
 #'
-#' @seealso [terra::app()], [terra::lapp()], [subst()], [classify()], and modules `r.mapcalc` in **GRASS** (viewable using `grassHelp("r.mapcalc")`)
+#' @seealso [terra::app()], [terra::lapp()], [subst()], [classify()], and especially **GRASS** manual page for module `r.mapcalc` (see `grassHelp("r.mapcalc")`)
 #'
 #' @example man/examples/ex_app.r
 #'

--- a/R/as.contour.r
+++ b/R/as.contour.r
@@ -9,7 +9,7 @@
 #'
 #' @param levels Numeric vector: A numeric vector of values at which to calculate contour lines. Either `nlevels` or `levels` must be specified.
 #'
-#' @seealso [terra::as.contour()], module `r.contour` in **GRASS**
+#' @seealso [terra::as.contour()], **GRASS** manual page for module `r.contour` (see `grassHelp("r.contour")`)
 #'
 #' @example man/examples/ex_asContour.r
 #'

--- a/R/backdoor.r
+++ b/R/backdoor.r
@@ -1,6 +1,6 @@
 #' Setup fasterRaster for ABS
 #'
-#' This is a secret function to be used for faster development of **fasterRaster**. It assume development is on a Windows machine.
+#' This is a secret function to be used for faster development of **fasterRaster**. It calls [faster()] to set the install directory for **GRASS**, increases default memory, and number of cores. The function assumes development is on a Windows machine.
 #'
 #' @param ver Character: **GRASS**: e.g., "83" or "84".
 #'

--- a/R/classify.r
+++ b/R/classify.r
@@ -1,6 +1,6 @@
 #' Classify GRaster cell values
 #'
-#' @description This function classifies a raster so that cells that have values within a given range are assigned a new value. The [subst()] function is a simpler method for replacing specific values or category levels.
+#' @description This function classifies a `GRaster`` so that cells that have values within a given range are assigned a new value. The [subst()] function is a simpler method for replacing specific values or category levels.
 #'
 #' @param x A `GRaster`.
 #' @param rcl Reclassification system:

--- a/R/cleanGeom.r
+++ b/R/cleanGeom.r
@@ -19,7 +19,7 @@
 #'
 #' @param tolerance Numeric or `NULL` (default): Minimum distance in map units (degrees for unprojected, usually meters for projected) or minimum area (in meters-squared, regardless of projection).
 #'
-#' @seealso [terra::topology()], [fillHoles()], [terra::removeDupNodes()], *Details* section in [fast()], [simplifyGeom()], [smoothGeom()]
+#' @seealso [terra::topology()], [fillHoles()], [terra::removeDupNodes()], *Details* section in [fast()], [simplifyGeom()], [smoothGeom()], **GRASS** manual page for module `v.clean` (see `grassHelp("v.clean")`)
 #'
 #' @returns A `GVector`.
 #'

--- a/R/clusterPoints.r
+++ b/R/clusterPoints.r
@@ -19,6 +19,8 @@
 #'
 #' @returns A vector of integers indicating the cluster to which each point belongs.
 #'
+#' @seealso **GRASS** manual page for module `v.cluster` (see `grassHelp("v.cluster")`)
+#'
 #' @aliases clusterPoints
 #' @rdname clusterPoints
 #' @exportMethod clusterPoints

--- a/R/compositeRGB.r
+++ b/R/compositeRGB.r
@@ -14,7 +14,7 @@
 #'
 #' @example man/examples/ex_plot.r
 #'
-#' @seealso [plotRGB()], [terra::plotRGB()]
+#' @seealso [plotRGB()], [terra::plotRGB()], **GRASS** manual page for module `r.composite` (see `grassHelp("r.composite")`)
 #'
 #' @aliases compositeRGB
 #' @rdname compositeRGB

--- a/R/concats.r
+++ b/R/concats.r
@@ -25,7 +25,7 @@
 #'
 #' @example man/examples/ex_GRaster_categorical.r
 #'
-#' @seealso [combineLevels()], [terra::concats()], `vignette("GRasters", package = "fasterRaster")`
+#' @seealso [combineLevels()], [terra::concats()], `vignette("GRasters", package = "fasterRaster")`, **GRASS** manual page for module `r.cross` (see `grassHelp("r.cross")`)
 #'
 #' @aliases concats
 #' @rdname concats

--- a/R/connectors.r
+++ b/R/connectors.r
@@ -7,7 +7,7 @@
 #'
 #' @returns A `GVector` with a data table that has the length of each connecting line in meters.
 #' 
-#' @seealso **GRASS** module `v.distance` (see `grassHelp("v.distance")`).
+#' @seealso **GRASS** manual for module `v.distance` (see `grassHelp("v.distance")`).
 #'
 #' @example man/examples/ex_connectors.r
 #'

--- a/R/denoise_noise.r
+++ b/R/denoise_noise.r
@@ -12,7 +12,7 @@
 #' 
 #' @returns A multi-layer `GRaster` with one layer per input.
 #' 
-#' @seealso [pca()]; [stats::prcomp()]; **GRASS** manual page for module `i.pca` (see `grassHelp("i.pca")`)
+#' @seealso [princomp()], [stats::prcomp()], **GRASS** manual page for module `i.pca` (see `grassHelp("i.pca")`)
 #' 
 #' @example man/examples/ex_denoise_noise.r
 #' 

--- a/R/denoise_noise.r
+++ b/R/denoise_noise.r
@@ -12,7 +12,7 @@
 #' 
 #' @returns A multi-layer `GRaster` with one layer per input.
 #' 
-#' @seealso [pca()]; [stats::prcomp()]; module `i.pca` in **GRASS**
+#' @seealso [pca()]; [stats::prcomp()]; **GRASS** manual page for module `i.pca` (see `grassHelp("i.pca")`)
 #' 
 #' @example man/examples/ex_denoise_noise.r
 #' 

--- a/R/fasterRaster.r
+++ b/R/fasterRaster.r
@@ -288,7 +288,6 @@
 #' * [reorient()]: Convert degrees between 'north-orientation' and 'east orientation'
 #' * [replaceNAs()]: Replace `NA`s in columns of a `data.table` or `data.frame`, or in a vector
 #' * [seqToSQL()]: Format a numeric series into an SQL value call
-#' * [workDir()]: 
 #' * [update()]: Refresh metadata in a `GRaster` or `GVector` object
 #'
 #' ## Data objects

--- a/R/fillHoles.r
+++ b/R/fillHoles.r
@@ -10,6 +10,8 @@
 #'
 #' @example man/examples/ex_GVector.r
 #'
+#' @seealso [terra::fillHoles()], **GRASS** manual page for module `v.fill.holes` (see `grassHelp("v.fill.holes")`)
+#'
 #' @aliases fillHoles
 #' @rdname fillHoles
 #' @exportMethod fillHoles

--- a/R/focal.r
+++ b/R/focal.r
@@ -33,7 +33,7 @@
 #'
 #' @returns A `GRaster`.
 #' 
-#' @seealso [terra::focal()], **GRASS** module `r.neighbors`
+#' @seealso [terra::focal()], **GRASS** manual page for module `r.neighbors` (see `grassHelp("r.neighbors")`)
 #' 
 #' @example man/examples/ex_focal.r
 #' 

--- a/R/fractalRast.r
+++ b/R/fractalRast.r
@@ -14,7 +14,7 @@
 #'
 #' @example man/examples/ex_randRast.r
 #' 
-#' @seealso [rSpatialDepRast()], [rnormRast()], [runifRast()], and module `r.surf.fractal` in **GRASS**
+#' @seealso [rSpatialDepRast()], [rnormRast()], [runifRast()], **GRASS** manual page for module `r.surf.fractal` (see `grassHelp("r.surf.fractal")`)
 #'
 #' @aliases fractalRast
 #' @rdname fractalRast

--- a/R/geomorphons.r
+++ b/R/geomorphons.r
@@ -29,7 +29,7 @@
 #'
 #' @returns A categorical `GRaster` where each geomorphon is a category (see `vignette("GRasters", package = "fasterRaster")`).
 #'
-#' @seealso **GRASS** module `r.geomorphon` (see `grassHelp("r.geomorphon")`)
+#' @seealso **GRASS** manual for module `r.geomorphon` (see `grassHelp("r.geomorphon")`)
 #'
 #' @example man/examples/ex_geomorphons.r
 #'

--- a/R/grassHelp.r
+++ b/R/grassHelp.r
@@ -4,8 +4,8 @@
 #'
 #' @param x Character: Any of:
 #' * The name of a **GRASS** module (e.g., `"r.mapcalc"`).
-#' * `"type"`: Display a page wherein modules are classified by types.
-#' * `"topics"`: Display an index of topics.
+#' * `"toc"`: **GRASS** manual table of contents.
+#' * `"index"`: Display an index of topics.
 #'
 #' @param online Logical: If `FALSE` (default), show the manual page that was included with your installation of **GRASS** on your computer.  If `FALSE`, show the manual page online (requires an Internet connection). In either case, the manual page will display for the version of **GRASS** you have installed.
 #'
@@ -34,10 +34,10 @@ grassHelp <- function(x, online = FALSE) {
 			flags = .quiet()
 		)
 		
-		if (x == "type") {
-			args$flags <- c(args$flags, "i")
-		} else if (x == "index") {
+		if (x == "index") {
 			args$flags <- c(args$flags, "t")
+		} else if (x == "toc") {
+			args$flags <- c(args$flags, "i")
 		}
 
 		do.call(rgrass::execGRASS, args = args)

--- a/R/hillshade.r
+++ b/R/hillshade.r
@@ -12,7 +12,7 @@
 #'
 #' @returns A `GRaster`.
 #'
-#' @seealso [terra::shade()], module `r.relief` in **GRASS**
+#' @seealso [terra::shade()]
 #' 
 #' @example man/examples/ex_terrain.r
 #' 

--- a/R/horizonHeight.r
+++ b/R/horizonHeight.r
@@ -18,7 +18,7 @@
 #'
 #' @returns A `GRaster` with one or more layers. The layers will be named `height_`*xyz*, where *xyz* is degrees from north or from east, depending on whether north or east orientation is used.
 #'
-#' @seealso The **GRASS** module `r.horizon`.
+#' @seealso **GRASS** manual page for module `r.horizon` (see `grassHelp("r.horizon")`)
 #'
 #' @example man/examples/ex_horizonHeight.r
 #' 

--- a/R/init.r
+++ b/R/init.r
@@ -69,7 +69,7 @@ methods::setMethod(
 		rgrass::execGRASS("r.mapcalc", expression = ex, flags = c(.quiet(), "overwrite"))
 
 	}
-	.makeGRaster(srcs, "layer")
+	.makeGRaster(srcs, fun)
 
 	} # EOF
 )

--- a/R/init.r
+++ b/R/init.r
@@ -12,8 +12,6 @@
 #'
 #' @param odd Logical: If `TRUE` (default), and `fun` is `"chess"`, then the top left cell in the raster will be a "negative" cell. If `FALSE`, then the top left cell with be "positive".
 #'
-#' @param every Numeric or integer: If `fun` is `"regular"`, then make every `every` cell a "positive" cell, and interstitial cells "negative." The default is 2 (every other cell).
-#'
 #' @param vals Vector of two numeric values: If `fun` is `"chess"` or `"regular"`, then assign the first value to "positive" cells and the second value to "negative" cells. The default is `c(1, 0)`
 #'
 #' @returns A `GRaster` with as many layers as `x`.

--- a/R/interpIDW.r
+++ b/R/interpIDW.r
@@ -14,7 +14,7 @@
 #'
 #' @returns A `GRaster`.
 #'
-#' @seealso [terra::interpIDW()], [interpSplines()], [fillNAs()], **GRASS** module `v.surf.idw` (se `grasshelp("v.surf.idw")`)
+#' @seealso [terra::interpIDW()], [interpSplines()], [fillNAs()], **GRASS** module `v.surf.idw` (se `grassHelp("v.surf.idw")`)
 #'
 #' @aliases interpIDW
 #' @rdname interpIDW

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -28,6 +28,8 @@
 #'
 #' Otherwise, if `h` is `NULL`, then the value will be arbitrarily set at 1/5th of the shorter of the distance of the x- and y-extent of the points.
 #'
+#' @seealso **GRASS** manual page for module `v.kernel` (see `grassHelp("v.kernel")`)
+#'
 #' @returns A `GRaster`.
 #'
 #' @example man/examples/ex_kernel.r

--- a/R/longlat.r
+++ b/R/longlat.r
@@ -29,7 +29,7 @@ methods::setMethod(
 )
 
 #' @noRd
-.longlat <- function(x) {
+.longlat <- function(x, degrees) {
 
     if (inherits(x, "GRaster")) {
         src <- sources(x)

--- a/R/longlat.r
+++ b/R/longlat.r
@@ -1,8 +1,10 @@
 #' Create longitude/latitude rasters
 #' 
-#' @description `longlat()` creates two rasters, one with cell values equal to the longitude of the cell centers, and one with cell values equal to the latitude of the cell centers. Values will be in decimal degrees, regardless of the projection of the raster. If you want projected coordinates, use [init()].
+#' @description `longlat()` creates two rasters, one with cell values equal to the longitude of the cell centers, and one with cell values equal to the latitude of the cell centers.
 #' 
 #' @param x A `GRaster`.
+#'
+#' @param degrees Logical: If `TRUE` (default), coordinate values of cells will be in degrees. If `FALSE`, and `x` is in a projected coordinate reference system, values will represent coordinates in map units (usually meters). Values will always be in degrees when the coordinate reference system is unprojected (e.g., WGS84, NAD83, etc.).
 #' 
 #' @returns A `GRaster` stack.
 #'
@@ -16,11 +18,11 @@
 methods::setMethod(
     f = "longlat",
     signature(x = "GRaster"),
-    function(x) {
+    function(x, degrees = TRUE) {
 
     .locationRestore(x)
     .region(x)
-    srcs <- .longlat(x)
+    srcs <- .longlat(x, degrees = degrees)
    .makeGRaster(srcs, c("longitude", "latitude"))
 
     } # EOF
@@ -36,19 +38,33 @@ methods::setMethod(
     }
 
     srcs <- .makeSourceName(c("longlat_long", "longlat_lat"), "raster")
-    rgrass::execGRASS(
-        cmd = "r.latlong",
-        input = src,
-        output = srcs[1L],
-        flags = c("l", .quiet(), "overwrite")
-    )
+    if (degrees) {
 
-    rgrass::execGRASS(
-        cmd = "r.latlong",
-        input = src,
-        output = srcs[2L],
-        flags = c(.quiet(), "overwrite")
-    )
+        rgrass::execGRASS(
+            cmd = "r.latlong",
+            input = src,
+            output = srcs[1L],
+            flags = c("l", .quiet(), "overwrite")
+        )
+
+        rgrass::execGRASS(
+            cmd = "r.latlong",
+            input = src,
+            output = srcs[2L],
+            flags = c(.quiet(), "overwrite")
+        )
+
+    } else {
+    
+        # longitude
+        ex <- paste0(srcs[1L], " = col(", src, ")")
+        rgrass::execGRASS("r.mapcalc", expression = ex, flags = c(.quiet(), "overwrite"))
+    
+        # latitude
+        ex <- paste0(srcs[2L], " = row(", src, ")")
+        rgrass::execGRASS("r.mapcalc", expression = ex, flags = c(.quiet(), "overwrite"))
+    
+    }
     srcs
 
 }

--- a/R/mow.r
+++ b/R/mow.r
@@ -16,7 +16,7 @@
 #'
 #' @returns Invisibly returns a list with the number of rasters and vectors deleted.
 #'
-#' @seealso Option `clean` in [faster()]; [grass()]
+#' @seealso Option `clean` in [faster()]
 #'
 #' @example man/examples/ex_mow.r
 #'

--- a/R/predict.r
+++ b/R/predict.r
@@ -2,13 +2,13 @@
 #'
 #' @description This version of the `predict()` function make predictions to a set of `GRaster`s from a model object.
 #'
-#' The model must be either a linear model, which is of class `lm` and typically created using the [stats::lm()] function or a generalized linear model (GLM), which is class `glm` and typically created using [stats::glm()]. Other packages can also create `lm` or `glm` objects, but they may not work in this function. For example, generalized additive models, which can be created using the `gam()` function in the **mgcv** package, inherit the `glm` class, but cannot be used in this function, but ones created with the **speedglm** package can.
+#' The model must be either a linear model, which is of class `lm` and typically created using the [stats::lm()] function or a generalized linear model (GLM), which is class `glm` and typically created using [stats::glm()]. Other packages can also create `lm` or `glm` objects, but they may not work in this function. For example, generalized additive models, which can be created using the `gam()` function in the **mgcv** package, inherit the `glm` class, but cannot be used in this function. However, `glm` objects created with the **speedglm** package should work with this function.
 #'
 #' This `predict()` function can handle:
-#' * Linear predictors and intercepts like `y ~ 1 + x`;
-#' * Quadratic terms like `y ~ x^2` (or, in **R** formula notation, `y ~ I(x^2)`);
-#' * Two-way interaction terms between scalars like `y ~ x1:x2` and `y ~ x1 * x2`;
-#' * Categorical predictors (i.e., categorical `GRaster`s; see `vignette("GRasters", package = "fasterRaster")`));
+#' * Linear predictors and intercepts like `1 + x`;
+#' * Quadratic terms like `x^2` (or, in **R** formula notation, `I(x^2)`);
+#' * Two-way interaction terms between scalars like `x1:x2` and `x1 * x2`;
+#' * Categorical predictors (i.e., categorical `GRaster`s; see `vignette("GRasters", package = "fasterRaster")`);
 #' * Two-way interactions between a categorical predictor and a scalar predictor; and
 #' * Two-way interactions between categorical predictors.
 #'

--- a/R/project.r
+++ b/R/project.r
@@ -41,7 +41,7 @@
 #' 
 #' @returns A `GRaster` or `GVector`.
 #' 
-#' @seealso [terra::project()], [sf::st_transform()], modules `r.proj`, `r.import`, and `v.proj` in **GRASS**
+#' @seealso [terra::project()], [sf::st_transform()], **GRASS** manual pages for modules `r.proj` and `v.proj` (see `grassHelp("r.proj")` and `grassHelp("v.proj")`)
 #'
 #' @example man/examples/ex_project.r
 #'

--- a/R/project.r
+++ b/R/project.r
@@ -387,11 +387,12 @@ methods::setMethod(
 		}
 
 	} # project next raster
-	
-	if (verbose | faster("verbose")) close(pb)
+
+	.locationRestore(y)
 
 	# if using y as extent to which to crop
 	if (!align & inherits(y, "GRaster")) out <- crop(out, y)
+	if (verbose | faster("verbose")) close(pb)
 	out
 
 }

--- a/R/rSpatialDepRast.r
+++ b/R/rSpatialDepRast.r
@@ -20,7 +20,7 @@
 #'
 #' @example man/examples/ex_randRast.r
 #' 
-#' @seealso [rnormRast()], [fractalRast()], [runifRast()], and **GRASS** module `r.random.surface`
+#' @seealso [rnormRast()], [fractalRast()], [runifRast()], **GRASS** manual page for module `r.random.surface` (see `grassHelp("r.random.surface")`)
 #'
 #' @aliases rSpatialDepRast
 #' @rdname rSpatialDepRast

--- a/R/rnormRast.r
+++ b/R/rnormRast.r
@@ -14,7 +14,7 @@
 #'
 #' @example man/examples/ex_randRast.r
 #' 
-#' @seealso [rSpatialDepRast()], [fractalRast()], [runifRast()], and **GRASS** module `r.random.surface`
+#' @seealso [rSpatialDepRast()], [fractalRast()], [runifRast()], **GRASS** manual page for module `r.random.surface` (see `grassHelp("r.random.surface")`)
 #'
 #' @aliases rnormRast
 #' @rdname rnormRast

--- a/R/simplifyGeom.r
+++ b/R/simplifyGeom.r
@@ -15,7 +15,7 @@
 #'
 #' @param prop Positive value between 0 and 1: Proportion of points that will be retained for each geometry when the Douglas-Peucker algorithm with reduction is applied (ignored otherwise). Default is 0.5 (retain 50% of vertices).
 #'
-#' @seealso [smoothGeom()], [geometry cleaning][breakPolys], [terra::simplifyGeom()]
+#' @seealso [smoothGeom()], [geometry cleaning][breakPolys], [terra::simplifyGeom()], **GRASS** manual page for module `v.generalize` (see `grassHelp("v.generalize")`)
 #'
 #' @returns A `GVector`.
 #'

--- a/R/smoothGeom.r
+++ b/R/smoothGeom.r
@@ -13,7 +13,7 @@
 #'
 #' @param angle Numeric > 0: Maximum angle for the Hermite algorithm. Default is 3.
 #'
-#' @seealso [simplifyGeom()], [terra::simplifyGeom()], [geometry cleaning][breakPolys]
+#' @seealso [simplifyGeom()], [terra::simplifyGeom()], [geometry cleaning][breakPolys], **GRASS** manual page for module `v.generalize` (see `grassHelp("v.generalize")`)
 #'
 #' @returns A `GVector`.
 #'

--- a/R/streams.r
+++ b/R/streams.r
@@ -20,7 +20,7 @@
 #'
 #' @example man/examples/ex_streams.r
 #'
-#' @seealso [flow()], [flowPath()], **GRASS** module `r.stream.extract` (see `grassHelp("r.stream.extract")`)
+#' @seealso [flow()], [flowPath()], **GRASS** manual for module `r.stream.extract` (see `grassHelp("r.stream.extract")`)
 #'
 #' @aliases streams
 #' @rdname streams

--- a/R/sun.r
+++ b/R/sun.r
@@ -51,7 +51,7 @@
 #' * `glob_rad`: Global radiation (Watt-hours/m2/day)
 #' * `insol_time`: Insolation duration (hours)
 #' 
-#' @seealso [terrain()], [horizonHeight()], **GRASS** module `r.sun`(see `grassHelp("r.sun")`)
+#' @seealso [terrain()], [horizonHeight()], **GRASS** manual page for module `r.sun` (see `grassHelp("r.sun")`)
 #'
 #' @example man/examples/ex_sun.r
 #'

--- a/R/thinLines.r
+++ b/R/thinLines.r
@@ -8,7 +8,7 @@
 #' 
 #' @returns A `GRaster`.
 #'
-#' @seealso [as.lines()]
+#' @seealso [as.lines()], **GRASS** manual page for module `r.thin` (see `grassHelp("r.thin")`)
 #' 
 #' @example man/examples/ex_asLines.r
 #' 

--- a/R/vegIndex.r
+++ b/R/vegIndex.r
@@ -21,7 +21,7 @@
 #' 
 #' @returns A `GRaster`.
 #' 
-#' @seealso Module `i.vi` in **GRASS**.
+#' @seealso **GRASS** manual page for module `i.vi` (see `grassHelp("i.vi")`)
 #' 
 #' @example man/examples/ex_vegIndex.r
 #' 

--- a/R/wetness.r
+++ b/R/wetness.r
@@ -6,7 +6,7 @@
 #'
 #' @returns A `GRaster`.
 #'
-#' @seealso [terrain()], [ruggedness()], [geomorphons()], **GRASS** module `r.topidx` (see `grassHelp("r.topidx")`)
+#' @seealso [terrain()], [ruggedness()], [geomorphons()], **GRASS** manual for module `r.topidx` (see `grassHelp("r.topidx")`)
 #'
 #' @example man/examples/ex_ruggedness_wetness.r
 #'

--- a/R/writeVector.r
+++ b/R/writeVector.r
@@ -35,7 +35,7 @@
 #'
 #' @example man/examples/ex_writeVector.r
 #'
-#' @seealso [terra::writeVector()]
+#' @seealso [terra::writeVector()], the **GRASS** module manual page for `v.out.ogr` (see `grassHelp("v.out.ogr")`)
 #'
 #' @aliases writeVector
 #' @rdname writeVector

--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@ Faster raster processing in `R` using `GRASS GIS`
  
 <a href="https://adamlilith.github.io/fasterRaster/"><img src="man/figures/logo.png" align="right" height="232" alt="fasterRaster website" /></a>
 
-`fasterRaster` is a package designed specifically to handle large-in-memory/large-on-disk spatial rasters and vectors. `fasterRaster` does this using Open Source Geospatial's <a href="https://grass.osgeo.org/rgrass/">`GRASS GIS`</a>
+`fasterRaster` is an **R** package designed specifically to handle large-in-memory/large-on-disk spatial rasters and vectors. `fasterRaster` does this using Open Source Geospatial's <a href="https://grass.osgeo.org/rgrass/">`GRASS GIS`</a>
 
 `fasterRaster` was created with five design principles:
 
 * **Value added**: `fasterRaster` complements `terra` and `sf`, and is highly dependent on them! It is useful for analyzing large-in-memory/large-on-disk rasters and vectors that those packages struggle to handle. For medium- and small-size objects, `terra` and `sf` will almost always be faster.  
 * **Familiarity**: If you know how to use `terra`, you basically know how to use `fasterRaster`! That's because most of the functions have the same name and almost the same arguments as `terra` functions.  
 * **Comparability**: To the degree possible, outputs from `fasterRaster` are the same as those from functions in `terra` with the same name.  
-* **Simplicity**: `GRASS` requires users to track things like "locations", "mapsets", and "regions" for which there is no comparable analog in the `terra` or `sf` packages. `fasterRaster` handles these behind the scenes so you don't need to.  
-* **It's R**: The `rgrass` package provides a powerful conduit through which you can run `GRASS` modules from `R`. As such, it provides much more flexibility than `fasterRaster`. However, to use `rgrass`, you need to know what `GRASS` modules you need and be familiar with `GRASS` syntax. `fasterRaster` obviates this step but uses `rgrass` as a backend, allowing you to focus on `R` syntax and look up help for functions the normal way you do in `R`. You don't need to know `GRASS`!
+* **Simplicity**: `GRASS` requires users to track things like "locations" or "projects", "mapsets", and "regions" for which there is no comparable analog in the `terra` or `sf` packages. `fasterRaster` handles these behind the scenes so you don't need to.  
+* **It's R**: The `rgrass` package provides a powerful conduit through which you can run `GRASS` modules from `R`. As such, it provides much more flexibility than `fasterRaster`. However, to use `rgrass`, you need to know what `GRASS` modules you want to use and be familiar with `GRASS` syntax. `fasterRaster` obviates this step but uses `rgrass` as a backend, allowing you to focus on `R` syntax and look up help for functions the normal way you do in `R`. You don't need to know `GRASS`!
 
-`fasterRaster` makes heavy use of the <a href="https://cran.r-project.org/package=rgrass">`rgrass`</a> package by Roger Bivand and others, the <a href="https://cran.r-project.org/package=rgrass">`terra`</a> package by Robert Hijmans, the <a href="https://cran.r-project.org/package=sf">`sf`</a> package by Edzer Pebesma Roger Bivand, and of course <a href="https://grass.osgeo.org/">`GRASS GIS`</a>, so is greatly indebted to all of these creators!
+`fasterRaster` makes heavy use of the <a href="https://cran.r-project.org/package=rgrass">`rgrass`</a> package by Roger Bivand and others, the <a href="https://cran.r-project.org/package=rgrass">`terra`</a> package by Robert Hijmans, the <a href="https://cran.r-project.org/package=sf">`sf`</a> package by Edzer Pebesma, Roger Bivand, and others, and of course <a href="https://grass.osgeo.org/">`GRASS GIS`</a>, so is greatly indebted to all of these creators!
 
 # Where we are
-As of 2024/09/15, a new version of this package, `fasterRaster 8.3`, is in alpha release (i.e., near final release). There are known issues and unknown issues. If you encounter one of the latter, please file an <a href="https://github.com/adamlilith/fasterRaster/issues">issue</a> report.
+As of 2024/10/18, a new version of this package, `fasterRaster 8.4`, is in alpha release (i.e., near final release) and can run with **GRASS** 8.3 or 8.4. There are known issues and unknown issues. If you encounter one of the latter, please file an <a href="https://github.com/adamlilith/fasterRaster/issues">issue</a> report.
 
 **Special announcement #1**: We now have a **pkgdown** <a href="https://adamlilith.github.io/fasterRaster/">site</a> with all the package documentation--plus vignettes!
 
@@ -41,7 +41,7 @@ Alternatively, you can install the development version from:
 
 `remotes::install_github('adamlilith/fasterRaster@intuitive_fasterRaster', dependencies = TRUE)`  
 
-To use `fasterRaster` you must install [GRASS version 8+](https://grass.osgeo.org/) on your operating system. **You will need to use the stand-alone installer, not the Open Source Geospatial (OS Geo) installer.**
+To use `fasterRaster` you must install [GRASS version 8.3+](https://grass.osgeo.org/) on your operating system. **You will need to use the stand-alone installer, not the Open Source Geospatial (OS Geo) installer.**
 
 ## An example
 

--- a/fasterRaster_workspace.code-workspace
+++ b/fasterRaster_workspace.code-workspace
@@ -24,6 +24,7 @@
 			"titleBar.activeForeground": "#e7e7e7",
 			"titleBar.inactiveForeground": "#e7e7e799"
 		},
-		"peacock.color": "#215732"
+		"peacock.color": "#215732",
+		"git.ignoreLimitWarning": true
 	}
 }

--- a/inst/pkgdown.yml
+++ b/inst/pkgdown.yml
@@ -8,7 +8,7 @@ articles:
   hidden_functions: hidden_functions.html
   projects_mapsets: projects_mapsets.html
   regions: regions.html
-last_built: 2024-10-07T14:52Z
+last_built: 2024-10-19T04:31Z
 urls:
   reference: https://github.com/adamlilith/fasterRaster/reference
   article: https://github.com/adamlilith/fasterRaster/articles

--- a/inst/pkgdown.yml
+++ b/inst/pkgdown.yml
@@ -8,7 +8,7 @@ articles:
   hidden_functions: hidden_functions.html
   projects_mapsets: projects_mapsets.html
   regions: regions.html
-last_built: 2024-10-19T04:31Z
+last_built: 2024-10-24T04:03Z
 urls:
   reference: https://github.com/adamlilith/fasterRaster/reference
   article: https://github.com/adamlilith/fasterRaster/articles

--- a/man/addCats.Rd
+++ b/man/addCats.Rd
@@ -157,5 +157,5 @@ levels(combinedNA)
 }
 }
 \seealso{
-\code{\link[terra:factors]{terra::addCats()}}, \code{\link[=combineCats]{combineCats()}}, \code{\link[=combineLevels]{combineLevels()}}, \code{\link[=droplevels]{droplevels()}}, \verb{vignette("GRasters", package = "fasterRaster"}
+\code{\link[terra:factors]{terra::addCats()}}, \code{\link[=concats]{concats()}}, \code{\link[=combineLevels]{combineLevels()}}, \code{\link[=droplevels]{droplevels()}}, \verb{vignette("GRasters", package = "fasterRaster"}
 }

--- a/man/app.Rd
+++ b/man/app.Rd
@@ -129,5 +129,5 @@ freq(rand) # cell frequencies
 }
 }
 \seealso{
-\code{\link[terra:app]{terra::app()}}, \code{\link[terra:lapp]{terra::lapp()}}, \code{\link[=subst]{subst()}}, \code{\link[=classify]{classify()}}, and modules \code{r.mapcalc} in \strong{GRASS} (viewable using \code{grassHelp("r.mapcalc")})
+\code{\link[terra:app]{terra::app()}}, \code{\link[terra:lapp]{terra::lapp()}}, \code{\link[=subst]{subst()}}, \code{\link[=classify]{classify()}}, and especially \strong{GRASS} manual page for module \code{r.mapcalc} (see \code{grassHelp("r.mapcalc")})
 }

--- a/man/as.contour.Rd
+++ b/man/as.contour.Rd
@@ -38,5 +38,5 @@ plot(conts, add = TRUE)
 }
 }
 \seealso{
-\code{\link[terra:contour]{terra::as.contour()}}, module \code{r.contour} in \strong{GRASS}
+\code{\link[terra:contour]{terra::as.contour()}}, \strong{GRASS} manual page for module \code{r.contour} (see \code{grassHelp("r.contour")})
 }

--- a/man/breakPolys.Rd
+++ b/man/breakPolys.Rd
@@ -158,5 +158,5 @@ legend("bottom",
 }
 }
 \seealso{
-\code{\link[terra:topology]{terra::topology()}}, \code{\link[=fillHoles]{fillHoles()}}, \code{\link[terra:topology]{terra::removeDupNodes()}}, \emph{Details} section in \code{\link[=fast]{fast()}}, \code{\link[=simplifyGeom]{simplifyGeom()}}, \code{\link[=smoothGeom]{smoothGeom()}}
+\code{\link[terra:topology]{terra::topology()}}, \code{\link[=fillHoles]{fillHoles()}}, \code{\link[terra:topology]{terra::removeDupNodes()}}, \emph{Details} section in \code{\link[=fast]{fast()}}, \code{\link[=simplifyGeom]{simplifyGeom()}}, \code{\link[=smoothGeom]{smoothGeom()}}, \strong{GRASS} manual page for module \code{v.clean} (see \code{grassHelp("v.clean")})
 }

--- a/man/classify.Rd
+++ b/man/classify.Rd
@@ -32,7 +32,7 @@
 A \code{GRaster}. The raster will be a categorical \code{GRaster} if the original values were continuous (i.e., a single- or double-precision raster), or of type "integer" if the input was an integer. See \code{vignette("GRasters", package = "fasterRaster")}.
 }
 \description{
-This function classifies a raster so that cells that have values within a given range are assigned a new value. The \code{\link[=subst]{subst()}} function is a simpler method for replacing specific values or category levels.
+This function classifies a `GRaster`` so that cells that have values within a given range are assigned a new value. The \code{\link[=subst]{subst()}} function is a simpler method for replacing specific values or category levels.
 }
 \examples{
 if (grassStarted()) {

--- a/man/clusterPoints.Rd
+++ b/man/clusterPoints.Rd
@@ -31,3 +31,6 @@ A vector of integers indicating the cluster to which each point belongs.
 \description{
 \code{clusterPoints()} partitions points in a "points" \code{GVector} into clusters.
 }
+\seealso{
+\strong{GRASS} manual page for module \code{v.cluster} (see \code{grassHelp("v.cluster")})
+}

--- a/man/compositeRGB.Rd
+++ b/man/compositeRGB.Rd
@@ -57,5 +57,5 @@ plot(comp, col = grays)
 }
 }
 \seealso{
-\code{\link[=plotRGB]{plotRGB()}}, \code{\link[terra:plotRGB]{terra::plotRGB()}}
+\code{\link[=plotRGB]{plotRGB()}}, \code{\link[terra:plotRGB]{terra::plotRGB()}}, \strong{GRASS} manual page for module \code{r.composite} (see \code{grassHelp("r.composite")})
 }

--- a/man/concats.Rd
+++ b/man/concats.Rd
@@ -158,5 +158,5 @@ levels(combinedNA)
 }
 }
 \seealso{
-\code{\link[=combineLevels]{combineLevels()}}, \code{\link[terra:concats]{terra::concats()}}, \code{vignette("GRasters", package = "fasterRaster")}
+\code{\link[=combineLevels]{combineLevels()}}, \code{\link[terra:concats]{terra::concats()}}, \code{vignette("GRasters", package = "fasterRaster")}, \strong{GRASS} manual page for module \code{r.cross} (see \code{grassHelp("r.cross")})
 }

--- a/man/connectors.Rd
+++ b/man/connectors.Rd
@@ -49,5 +49,5 @@ plot(consFromRivers, col = "red", add = TRUE)
 }
 }
 \seealso{
-\strong{GRASS} module \code{v.distance} (see \code{grassHelp("v.distance")}).
+\strong{GRASS} manual for module \code{v.distance} (see \code{grassHelp("v.distance")}).
 }

--- a/man/denoise.Rd
+++ b/man/denoise.Rd
@@ -59,5 +59,5 @@ plot(compare2)
 }
 }
 \seealso{
-\code{\link[=pca]{pca()}}; \code{\link[stats:prcomp]{stats::prcomp()}}; \strong{GRASS} manual page for module \code{i.pca} (see \code{grassHelp("i.pca")})
+\code{\link[=princomp]{princomp()}}, \code{\link[stats:prcomp]{stats::prcomp()}}, \strong{GRASS} manual page for module \code{i.pca} (see \code{grassHelp("i.pca")})
 }

--- a/man/denoise.Rd
+++ b/man/denoise.Rd
@@ -59,5 +59,5 @@ plot(compare2)
 }
 }
 \seealso{
-\code{\link[=pca]{pca()}}; \code{\link[stats:prcomp]{stats::prcomp()}}; module \code{i.pca} in \strong{GRASS}
+\code{\link[=pca]{pca()}}; \code{\link[stats:prcomp]{stats::prcomp()}}; \strong{GRASS} manual page for module \code{i.pca} (see \code{grassHelp("i.pca")})
 }

--- a/man/dot-backdoor.Rd
+++ b/man/dot-backdoor.Rd
@@ -13,6 +13,6 @@
 \code{TRUE} (invisibly).
 }
 \description{
-This is a secret function to be used for faster development of \strong{fasterRaster}. It assume development is on a Windows machine.
+This is a secret function to be used for faster development of \strong{fasterRaster}. It calls \code{\link[=faster]{faster()}} to set the install directory for \strong{GRASS}, increases default memory, and number of cores. The function assumes development is on a Windows machine.
 }
 \keyword{internal}

--- a/man/examples/ex_fast.r
+++ b/man/examples/ex_fast.r
@@ -45,13 +45,13 @@ class(madRivers)
 rivers <- fast(madRivers)
 rivers
 
-# Create a GVector from a vector on disk
+# Create a GVector from a vector on disk:
 vectFile <- system.file("extdata/shapes", "madCoast.shp",
    package = "fasterRaster")
 coast0 <- fast(vectFile)
 coast0
 
-# Import only Dypsis occurrences in a restricted area
+# Import only Dypsis occurrences in a restricted area:
 ant <- coast4[coast4$NAME_4 == "Antanambe"]
 dypsisRestrict <- fast(madDypsis, extent = ant)
 dypsis <- fast(madDypsis)
@@ -61,7 +61,7 @@ plot(ant, col = "gray80", add = TRUE)
 plot(dypsis, add = TRUE)
 plot(dypsisRestrict, col = "red", add = TRUE)
 
-# Create a generic GVector that spans the world
+# Create a generic GVector that spans the world:
 wallToWall <- fast(rastOrVect = "vector", crs = "epsg:4326") # WGS84
 wallToWall
 
@@ -69,7 +69,7 @@ wallToWall
 pts <- c(-90.2, 38.6, -122.3, 37.9)
 pts <- fast(pts, crs = "epsg:4326") # WGS84
 
-# Create a GVector from a matrix (can also use data.frame or data.table)
+# Create a GVector from a matrix (can also use data.frame or data.table):
 mat <- matrix(c(-90.2, 38.6, -122.3, 37.9), ncol = 2, byrow = TRUE)
 mat <- fast(mat, crs = "epsg:4326", keepgeom = TRUE) # WGS84
 

--- a/man/examples/ex_fillNAs.r
+++ b/man/examples/ex_fillNAs.r
@@ -10,11 +10,11 @@ madElev <- fastData("madElev")
 elev <- fast(madElev)
 
 ### Fill NAs:
-biline <- interp <- fillNAs(elev)
-bicube <- interp <- fillNAs(elev, method = "bicubic")
-rst <- interp <- fillNAs(elev, method = "rst")
+bilinear <- fillNAs(elev)
+bicubic <- fillNAs(elev, method = "bicubic")
+rst <- fillNAs(elev, method = "rst")
 
-maps <- c(elev, biline, bicube, rst)
+maps <- c(elev, bilinear, bicubic, rst)
 names(maps) <- c("original", "bilinear", "bicubic", "RST")
 plot(maps)
 
@@ -22,7 +22,7 @@ plot(maps)
 constrained <- fillNAs(elev, min = 0)
 
 # Compare unconstrained and constrained:
-minmax(biline)
+minmax(bilinear)
 minmax(constrained)
 
 ### Interpolate to only first 10 cells away from non-NA cells:

--- a/man/examples/ex_grassHelp.r
+++ b/man/examples/ex_grassHelp.r
@@ -4,10 +4,10 @@ if (grassStarted() & interactive()) {
 grassHelp("r.mapcalc")
 grassHelp("r.sun")
 
-# Open topics page:
-grassHelp("topics")
+# GRASS table of contents:
+grassHelp("toc")
 
-# Open index page:
+# Index page:
 grassHelp("index")
 
 }

--- a/man/examples/ex_scale_unscale.r
+++ b/man/examples/ex_scale_unscale.r
@@ -14,7 +14,7 @@ chelsa <- fast(madChelsa)
 chScaled <- scale(chelsa)
 chScaled
 
-# Scale with using sample SD:
+# Scale with using population SD:
 chScaledPop <- scalepop(chelsa)
 chScaledPop
 

--- a/man/fast.Rd
+++ b/man/fast.Rd
@@ -200,13 +200,13 @@ class(madRivers)
 rivers <- fast(madRivers)
 rivers
 
-# Create a GVector from a vector on disk
+# Create a GVector from a vector on disk:
 vectFile <- system.file("extdata/shapes", "madCoast.shp",
    package = "fasterRaster")
 coast0 <- fast(vectFile)
 coast0
 
-# Import only Dypsis occurrences in a restricted area
+# Import only Dypsis occurrences in a restricted area:
 ant <- coast4[coast4$NAME_4 == "Antanambe"]
 dypsisRestrict <- fast(madDypsis, extent = ant)
 dypsis <- fast(madDypsis)
@@ -216,7 +216,7 @@ plot(ant, col = "gray80", add = TRUE)
 plot(dypsis, add = TRUE)
 plot(dypsisRestrict, col = "red", add = TRUE)
 
-# Create a generic GVector that spans the world
+# Create a generic GVector that spans the world:
 wallToWall <- fast(rastOrVect = "vector", crs = "epsg:4326") # WGS84
 wallToWall
 
@@ -224,7 +224,7 @@ wallToWall
 pts <- c(-90.2, 38.6, -122.3, 37.9)
 pts <- fast(pts, crs = "epsg:4326") # WGS84
 
-# Create a GVector from a matrix (can also use data.frame or data.table)
+# Create a GVector from a matrix (can also use data.frame or data.table):
 mat <- matrix(c(-90.2, 38.6, -122.3, 37.9), ncol = 2, byrow = TRUE)
 mat <- fast(mat, crs = "epsg:4326", keepgeom = TRUE) # WGS84
 

--- a/man/fasterRaster.Rd
+++ b/man/fasterRaster.Rd
@@ -345,7 +345,6 @@ Operations on \code{GRaster}s
 \item \code{\link[=reorient]{reorient()}}: Convert degrees between 'north-orientation' and 'east orientation'
 \item \code{\link[=replaceNAs]{replaceNAs()}}: Replace \code{NA}s in columns of a \code{data.table} or \code{data.frame}, or in a vector
 \item \code{\link[=seqToSQL]{seqToSQL()}}: Format a numeric series into an SQL value call
-\item \code{\link[=workDir]{workDir()}}:
 \item \code{\link[=update]{update()}}: Refresh metadata in a \code{GRaster} or \code{GVector} object
 }
 }

--- a/man/fillHoles.Rd
+++ b/man/fillHoles.Rd
@@ -124,3 +124,6 @@ filled <- fillHoles(holes, fail = FALSE)
 
 }
 }
+\seealso{
+\code{\link[terra:fill]{terra::fillHoles()}}, \strong{GRASS} manual page for module \code{v.fill.holes} (see \code{grassHelp("v.fill.holes")})
+}

--- a/man/fillNAs.Rd
+++ b/man/fillNAs.Rd
@@ -46,11 +46,11 @@ madElev <- fastData("madElev")
 elev <- fast(madElev)
 
 ### Fill NAs:
-biline <- interp <- fillNAs(elev)
-bicube <- interp <- fillNAs(elev, method = "bicubic")
-rst <- interp <- fillNAs(elev, method = "rst")
+bilinear <- fillNAs(elev)
+bicubic <- fillNAs(elev, method = "bicubic")
+rst <- fillNAs(elev, method = "rst")
 
-maps <- c(elev, biline, bicube, rst)
+maps <- c(elev, bilinear, bicubic, rst)
 names(maps) <- c("original", "bilinear", "bicubic", "RST")
 plot(maps)
 
@@ -58,7 +58,7 @@ plot(maps)
 constrained <- fillNAs(elev, min = 0)
 
 # Compare unconstrained and constrained:
-minmax(biline)
+minmax(bilinear)
 minmax(constrained)
 
 ### Interpolate to only first 10 cells away from non-NA cells:

--- a/man/focal.Rd
+++ b/man/focal.Rd
@@ -83,5 +83,5 @@ minmax(s)
 }
 }
 \seealso{
-\code{\link[terra:focal]{terra::focal()}}, \strong{GRASS} module \code{r.neighbors}
+\code{\link[terra:focal]{terra::focal()}}, \strong{GRASS} manual page for module \code{r.neighbors} (see \code{grassHelp("r.neighbors")})
 }

--- a/man/fractalRast.Rd
+++ b/man/fractalRast.Rd
@@ -62,5 +62,5 @@ hist(fractal)
 }
 }
 \seealso{
-\code{\link[=rSpatialDepRast]{rSpatialDepRast()}}, \code{\link[=rnormRast]{rnormRast()}}, \code{\link[=runifRast]{runifRast()}}, and module \code{r.surf.fractal} in \strong{GRASS}
+\code{\link[=rSpatialDepRast]{rSpatialDepRast()}}, \code{\link[=rnormRast]{rnormRast()}}, \code{\link[=runifRast]{runifRast()}}, \strong{GRASS} manual page for module \code{r.surf.fractal} (see \code{grassHelp("r.surf.fractal")})
 }

--- a/man/geomorphons.Rd
+++ b/man/geomorphons.Rd
@@ -76,5 +76,5 @@ plot(geos, col = col)
 }
 }
 \seealso{
-\strong{GRASS} module \code{r.geomorphon} (see \code{grassHelp("r.geomorphon")})
+\strong{GRASS} manual for module \code{r.geomorphon} (see \code{grassHelp("r.geomorphon")})
 }

--- a/man/grassHelp.Rd
+++ b/man/grassHelp.Rd
@@ -10,8 +10,8 @@ grassHelp(x, online = FALSE)
 \item{x}{Character: Any of:
 \itemize{
 \item The name of a \strong{GRASS} module (e.g., \code{"r.mapcalc"}).
-\item \code{"type"}: Display a page wherein modules are classified by types.
-\item \code{"topics"}: Display an index of topics.
+\item \code{"toc"}: \strong{GRASS} manual table of contents.
+\item \code{"index"}: Display an index of topics.
 }}
 
 \item{online}{Logical: If \code{FALSE} (default), show the manual page that was included with your installation of \strong{GRASS} on your computer.  If \code{FALSE}, show the manual page online (requires an Internet connection). In either case, the manual page will display for the version of \strong{GRASS} you have installed.}
@@ -29,10 +29,10 @@ if (grassStarted() & interactive()) {
 grassHelp("r.mapcalc")
 grassHelp("r.sun")
 
-# Open topics page:
-grassHelp("topics")
+# GRASS table of contents:
+grassHelp("toc")
 
-# Open index page:
+# Index page:
 grassHelp("index")
 
 }

--- a/man/hillshade.Rd
+++ b/man/hillshade.Rd
@@ -47,5 +47,5 @@ plot(hs)
 }
 }
 \seealso{
-\code{\link[terra:shade]{terra::shade()}}, module \code{r.relief} in \strong{GRASS}
+\code{\link[terra:shade]{terra::shade()}}
 }

--- a/man/horizonHeight.Rd
+++ b/man/horizonHeight.Rd
@@ -61,5 +61,5 @@ plot(hhEast)
 }
 }
 \seealso{
-The \strong{GRASS} module \code{r.horizon}.
+\strong{GRASS} manual page for module \code{r.horizon} (see \code{grassHelp("r.horizon")})
 }

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -21,8 +21,6 @@
 \item{odd}{Logical: If \code{TRUE} (default), and \code{fun} is \code{"chess"}, then the top left cell in the raster will be a "negative" cell. If \code{FALSE}, then the top left cell with be "positive".}
 
 \item{vals}{Vector of two numeric values: If \code{fun} is \code{"chess"} or \code{"regular"}, then assign the first value to "positive" cells and the second value to "negative" cells. The default is \code{c(1, 0)}}
-
-\item{every}{Numeric or integer: If \code{fun} is \code{"regular"}, then make every \code{every} cell a "positive" cell, and interstitial cells "negative." The default is 2 (every other cell).}
 }
 \value{
 A \code{GRaster} with as many layers as \code{x}.

--- a/man/interpIDW.Rd
+++ b/man/interpIDW.Rd
@@ -25,5 +25,5 @@ A \code{GRaster}.
 This function interpolates values from a set of points to a raster using inverse distance weighting (IDW).
 }
 \seealso{
-\code{\link[terra:interpIDW]{terra::interpIDW()}}, \code{\link[=interpSplines]{interpSplines()}}, \code{\link[=fillNAs]{fillNAs()}}, \strong{GRASS} module \code{v.surf.idw} (se \code{grasshelp("v.surf.idw")})
+\code{\link[terra:interpIDW]{terra::interpIDW()}}, \code{\link[=interpSplines]{interpSplines()}}, \code{\link[=fillNAs]{fillNAs()}}, \strong{GRASS} module \code{v.surf.idw} (se \code{grassHelp("v.surf.idw")})
 }

--- a/man/kernel.Rd
+++ b/man/kernel.Rd
@@ -65,3 +65,6 @@ plot(dypsis, add = TRUE, pch = 1)
 
 }
 }
+\seealso{
+\strong{GRASS} manual page for module \code{v.kernel} (see \code{grassHelp("v.kernel")})
+}

--- a/man/longlat.Rd
+++ b/man/longlat.Rd
@@ -5,16 +5,18 @@
 \alias{longlat}
 \title{Create longitude/latitude rasters}
 \usage{
-\S4method{longlat}{GRaster}(x)
+\S4method{longlat}{GRaster}(x, degrees = TRUE)
 }
 \arguments{
 \item{x}{A \code{GRaster}.}
+
+\item{degrees}{Logical: If \code{TRUE} (default), coordinate values of cells will be in degrees. If \code{FALSE}, and \code{x} is in a projected coordinate reference system, values will represent coordinates in map units (usually meters). Values will always be in degrees when the coordinate reference system is unprojected (e.g., WGS84, NAD83, etc.).}
 }
 \value{
 A \code{GRaster} stack.
 }
 \description{
-\code{longlat()} creates two rasters, one with cell values equal to the longitude of the cell centers, and one with cell values equal to the latitude of the cell centers. Values will be in decimal degrees, regardless of the projection of the raster. If you want projected coordinates, use \code{\link[=init]{init()}}.
+\code{longlat()} creates two rasters, one with cell values equal to the longitude of the cell centers, and one with cell values equal to the latitude of the cell centers.
 }
 \examples{
 if (grassStarted()) {

--- a/man/mow.Rd
+++ b/man/mow.Rd
@@ -33,5 +33,5 @@ if (FALSE) mow()
 }
 }
 \seealso{
-Option \code{clean} in \code{\link[=faster]{faster()}}; \code{\link[=grass]{grass()}}
+Option \code{clean} in \code{\link[=faster]{faster()}}
 }

--- a/man/predict.Rd
+++ b/man/predict.Rd
@@ -20,14 +20,14 @@ A \code{GRaster}.
 \description{
 This version of the \code{predict()} function make predictions to a set of \code{GRaster}s from a model object.
 
-The model must be either a linear model, which is of class \code{lm} and typically created using the \code{\link[stats:lm]{stats::lm()}} function or a generalized linear model (GLM), which is class \code{glm} and typically created using \code{\link[stats:glm]{stats::glm()}}. Other packages can also create \code{lm} or \code{glm} objects, but they may not work in this function. For example, generalized additive models, which can be created using the \code{gam()} function in the \strong{mgcv} package, inherit the \code{glm} class, but cannot be used in this function, but ones created with the \strong{speedglm} package can.
+The model must be either a linear model, which is of class \code{lm} and typically created using the \code{\link[stats:lm]{stats::lm()}} function or a generalized linear model (GLM), which is class \code{glm} and typically created using \code{\link[stats:glm]{stats::glm()}}. Other packages can also create \code{lm} or \code{glm} objects, but they may not work in this function. For example, generalized additive models, which can be created using the \code{gam()} function in the \strong{mgcv} package, inherit the \code{glm} class, but cannot be used in this function. However, \code{glm} objects created with the \strong{speedglm} package should work with this function.
 
 This \code{predict()} function can handle:
 \itemize{
-\item Linear predictors and intercepts like \code{y ~ 1 + x};
-\item Quadratic terms like \code{y ~ x^2} (or, in \strong{R} formula notation, \code{y ~ I(x^2)});
-\item Two-way interaction terms between scalars like \code{y ~ x1:x2} and \code{y ~ x1 * x2};
-\item Categorical predictors (i.e., categorical \code{GRaster}s; see \code{vignette("GRasters", package = "fasterRaster")}));
+\item Linear predictors and intercepts like \code{1 + x};
+\item Quadratic terms like \code{x^2} (or, in \strong{R} formula notation, \code{I(x^2)});
+\item Two-way interaction terms between scalars like \code{x1:x2} and \code{x1 * x2};
+\item Categorical predictors (i.e., categorical \code{GRaster}s; see \code{vignette("GRasters", package = "fasterRaster")});
 \item Two-way interactions between a categorical predictor and a scalar predictor; and
 \item Two-way interactions between categorical predictors.
 }

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -112,5 +112,5 @@ cat(crs(riversWGS84))
 }
 }
 \seealso{
-\code{\link[terra:project]{terra::project()}}, \code{\link[sf:st_transform]{sf::st_transform()}}, modules \code{r.proj}, \code{r.import}, and \code{v.proj} in \strong{GRASS}
+\code{\link[terra:project]{terra::project()}}, \code{\link[sf:st_transform]{sf::st_transform()}}, \strong{GRASS} manual pages for modules \code{r.proj} and \code{v.proj} (see \code{grassHelp("r.proj")} and \code{grassHelp("v.proj")})
 }

--- a/man/rSpatialDepRast.Rd
+++ b/man/rSpatialDepRast.Rd
@@ -77,5 +77,5 @@ hist(fractal)
 }
 }
 \seealso{
-\code{\link[=rnormRast]{rnormRast()}}, \code{\link[=fractalRast]{fractalRast()}}, \code{\link[=runifRast]{runifRast()}}, and \strong{GRASS} module \code{r.random.surface}
+\code{\link[=rnormRast]{rnormRast()}}, \code{\link[=fractalRast]{fractalRast()}}, \code{\link[=runifRast]{runifRast()}}, \strong{GRASS} manual page for module \code{r.random.surface} (see \code{grassHelp("r.random.surface")})
 }

--- a/man/rnormRast.Rd
+++ b/man/rnormRast.Rd
@@ -62,5 +62,5 @@ hist(fractal)
 }
 }
 \seealso{
-\code{\link[=rSpatialDepRast]{rSpatialDepRast()}}, \code{\link[=fractalRast]{fractalRast()}}, \code{\link[=runifRast]{runifRast()}}, and \strong{GRASS} module \code{r.random.surface}
+\code{\link[=rSpatialDepRast]{rSpatialDepRast()}}, \code{\link[=fractalRast]{fractalRast()}}, \code{\link[=runifRast]{runifRast()}}, \strong{GRASS} manual page for module \code{r.random.surface} (see \code{grassHelp("r.random.surface")})
 }

--- a/man/scale.Rd
+++ b/man/scale.Rd
@@ -55,7 +55,7 @@ chelsa <- fast(madChelsa)
 chScaled <- scale(chelsa)
 chScaled
 
-# Scale with using sample SD:
+# Scale with using population SD:
 chScaledPop <- scalepop(chelsa)
 chScaledPop
 

--- a/man/simplifyGeom.Rd
+++ b/man/simplifyGeom.Rd
@@ -110,5 +110,5 @@ legend("bottom",
 }
 }
 \seealso{
-\code{\link[=smoothGeom]{smoothGeom()}}, \link[=breakPolys]{geometry cleaning}, \code{\link[terra:simplify]{terra::simplifyGeom()}}
+\code{\link[=smoothGeom]{smoothGeom()}}, \link[=breakPolys]{geometry cleaning}, \code{\link[terra:simplify]{terra::simplifyGeom()}}, \strong{GRASS} manual page for module \code{v.generalize} (see \code{grassHelp("v.generalize")})
 }

--- a/man/smoothGeom.Rd
+++ b/man/smoothGeom.Rd
@@ -108,5 +108,5 @@ legend("bottom",
 }
 }
 \seealso{
-\code{\link[=simplifyGeom]{simplifyGeom()}}, \code{\link[terra:simplify]{terra::simplifyGeom()}}, \link[=breakPolys]{geometry cleaning}
+\code{\link[=simplifyGeom]{simplifyGeom()}}, \code{\link[terra:simplify]{terra::simplifyGeom()}}, \link[=breakPolys]{geometry cleaning}, \strong{GRASS} manual page for module \code{v.generalize} (see \code{grassHelp("v.generalize")})
 }

--- a/man/streams.Rd
+++ b/man/streams.Rd
@@ -55,5 +55,5 @@ plot(streams)
 }
 }
 \seealso{
-\code{\link[=flow]{flow()}}, \code{\link[=flowPath]{flowPath()}}, \strong{GRASS} module \code{r.stream.extract} (see \code{grassHelp("r.stream.extract")})
+\code{\link[=flow]{flow()}}, \code{\link[=flowPath]{flowPath()}}, \strong{GRASS} manual for module \code{r.stream.extract} (see \code{grassHelp("r.stream.extract")})
 }

--- a/man/sun.Rd
+++ b/man/sun.Rd
@@ -146,5 +146,5 @@ solar
 }
 }
 \seealso{
-\code{\link[=terrain]{terrain()}}, \code{\link[=horizonHeight]{horizonHeight()}}, \strong{GRASS} module \code{r.sun}(see \code{grassHelp("r.sun")})
+\code{\link[=terrain]{terrain()}}, \code{\link[=horizonHeight]{horizonHeight()}}, \strong{GRASS} manual page for module \code{r.sun} (see \code{grassHelp("r.sun")})
 }

--- a/man/thinLines.Rd
+++ b/man/thinLines.Rd
@@ -47,5 +47,5 @@ plot(cleanLines, add = TRUE)
 }
 }
 \seealso{
-\code{\link[=as.lines]{as.lines()}}
+\code{\link[=as.lines]{as.lines()}}, \strong{GRASS} manual page for module \code{r.thin} (see \code{grassHelp("r.thin")})
 }

--- a/man/vegIndex.Rd
+++ b/man/vegIndex.Rd
@@ -76,5 +76,5 @@ plot(rnir)
 }
 }
 \seealso{
-Module \code{i.vi} in \strong{GRASS}.
+\strong{GRASS} manual page for module \code{i.vi} (see \code{grassHelp("i.vi")})
 }

--- a/man/wetness.Rd
+++ b/man/wetness.Rd
@@ -39,5 +39,5 @@ plot(c(elev, twi))
 }
 }
 \seealso{
-\code{\link[=terrain]{terrain()}}, \code{\link[=ruggedness]{ruggedness()}}, \code{\link[=geomorphons]{geomorphons()}}, \strong{GRASS} module \code{r.topidx} (see \code{grassHelp("r.topidx")})
+\code{\link[=terrain]{terrain()}}, \code{\link[=ruggedness]{ruggedness()}}, \code{\link[=geomorphons]{geomorphons()}}, \strong{GRASS} manual for module \code{r.topidx} (see \code{grassHelp("r.topidx")})
 }

--- a/man/writeRaster.Rd
+++ b/man/writeRaster.Rd
@@ -12,6 +12,7 @@
   overwrite = FALSE,
   datatype = NULL,
   byLayer = FALSE,
+  names = TRUE,
   levelsExt = NULL,
   compress = "LZW",
   warn = TRUE,
@@ -42,6 +43,8 @@
 \code{*} Depends on the integers (signed/unsigned, range of values). Categorical rasters will have an associated file saved with them that has category values and labels. The file name will be the same as the raster's file name, but end with the extension given by \code{levelsExt} (\code{.csv} by default).}
 
 \item{byLayer}{Logical: If \code{FALSE} (default), multi-layer rasters will be saved in one file. If \code{TRUE}, the each layer will be saved in a separate file. The filename from \code{filename} will be amended so that it ends with \verb{_<name>} (then the file extension), where \verb{<name>} is give by \code{\link[=names]{names()}}. Note that if any characters in raster names will not work in a file name, then the function will fail (e.g., a backslash or question mark).}
+
+\item{names}{Logical: If \code{TRUE} (default), save a file with raster layer names. The file will have the same name as the raster file but end with "\verb{_names.csv}". Currently, the \code{\link[=names]{names()}} attribute of rasters cannot be saved in the raster, which can create confusion when multi-layered rasters are saved. Turning on this option will save the ancillary file with layer names. If it exists, this file will be read by \code{\link[=fast]{fast()}} so layer names are assigned when the raster is read by that function. The absence of a "names" file will not create any issues with this function or \code{\link[=fast]{fast()}}, other than not having the metadata on layer names.}
 
 \item{levelsExt}{Character, logical, or \code{NULL} (default): Name of the file extension for the "levels" file that accompanies a categorical \code{GRaster}. When saving categorical rasters, the raster file is accompanied with a "levels" file that contain information on the levels of the raster. This file is the same as \code{filename}, except it has a different extension. Valid values depend on how many raster layers are saved at a time (case is ignored):
 \itemize{

--- a/man/writeVector.Rd
+++ b/man/writeVector.Rd
@@ -99,5 +99,5 @@ writeVector(rivers, filename)
 \seealso{
 \code{\link[terra:writeVector]{terra::writeVector()}}, \code{\link[sf:st_write]{sf::st_write()}}, \strong{GRASS} module \code{v.out.ogr} (see \code{grassHelp("v.out.ogr")})
 
-\code{\link[terra:writeVector]{terra::writeVector()}}
+\code{\link[terra:writeVector]{terra::writeVector()}}, the \strong{GRASS} module manual page for \code{v.out.ogr} (see \code{grassHelp("v.out.ogr")})
 }

--- a/vignettes/fasterRaster.Rmd
+++ b/vignettes/fasterRaster.Rmd
@@ -251,4 +251,12 @@ vect_temp_file <- tempfile(fileext = ".shp") # save as shapefile
 writeVector(rivers, vect_temp_file)
 ```
 
+# Known issues
+
+* Comparability between **terra** and **fasterRaster**: As much as possible, **fasterRaster** functions were written to recreate the output that functions in **terra** produce.  However, owing to implementation choices made by the respective developers of **terra** and **GRASS**, outputs are not always the same.
+
+* **fasterRaster** can crash when the temporary folder is cleaned: Some operating systems have automated procedures that clean out the system's temporary folders when they get too large. This can remove files **GRASS** is using and **fasterRaster** is pointing to, rendering them broken. In Windows, this setting can be changed by going to `Settings`, then `Storage`, then `Storage Sense`. Turn off the setting "Keep Windows running smoothly by automatically cleaning up temporary system and app files".
+
+* Disk space fills up: As counter to the previous issue, prolonged use of **fasterRaster** by the same **R** process can create a lot of temporary files in the **GRASS** cache that fills your hard drive. **fasterRaster** does its best to remove these files when they are not needed, so long as the setting `faster('clean')` is `TRUE` (which it is by default). However, temporary files can still accumulate. For example, the operation `new_raster <- 2 * old_raster^3` creates a raster file with the `^3` operation, which is then multipled by 2 to get the desired output. But the raster from the `^3` operation is still left in the disk cache, even though it does not have a "name" in **R**. Again, judicious use of the [mow()] function can remove these temporary files.
+
 ~ FINIS ~


### PR DESCRIPTION
# fasterRaster 8.4.0.7028 (2024-10-24)

### Main task
o Clear for CRAN submission

### Enhanced functionality and new functions
o `grassHelp()` can show the **GRASS** manual "table of contents" (argument `"toc"`).  
o `longlat()` can now return rasters with cell values equal to their coordinates in map units (previously, only coordinates in degrees were returned).  
o For functions that are complicated or have extended references, added a note to the `@seealso` tag to see the respective **GRASS** manual page using `grassHelp()`.  

### Bug and issue fixes
o `project()` correctly restores the user's "location" to that of the newly projected `GRaster`.  
