### PR TITLE
proper linking

### DIFF
--- a/man/convHull.Rd
+++ b/man/convHull.Rd
@@ -48,5 +48,5 @@ for (i in 1:n) {
 }
 }
 \seealso{
-\code{\link[terra:convhull]{terra::convHull()}}, \code{\link[sf:geos_unary]{sf::st_convex_hull()}}, module \code{v.hull} in \strong{GRASS}
+\code{\link[terra]{convHull}}, \code{\link[sf:geos_unary]{sf::st_convex_hull()}}, module \code{v.hull} in \strong{GRASS}
 }


### PR DESCRIPTION
Hi Adam, 

I fixed a link in the convHull entry of the manual to that method in the "terra" manual. You were linking to a particular file 

```
\link[terra:convhull]{terra::convHull()}}
```

You can link to the package::method like this 

```
\link[terra]{convHull}}
```

That is a better approach, because it won't break if the filename changes. (I noticed this in a reverse dependency check). I assume you have many more of these.

Cheers, Robert

PS: I now see that you use Roxygen to generate these, so the PR is not very useful. I do not use Roxygen, but I assume you can fix it with that system as well.