### PR TITLE
Intuitive faster raster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fasterRaster
 Type: Package
 Title: Faster Raster and Spatial Vector Processing Using 'GRASS GIS'
-Version: 8.4.0.4
-Date: 2024-12-31
+Version: 8.4.0.5
+Date: 2025-02-17
 Authors@R: 
 	c(
 		person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: fasterRaster
 Type: Package
 Title: Faster Raster and Spatial Vector Processing Using 'GRASS GIS'
 Version: 8.4.0.4
-Date: 2024-12-16
+Date: 2024-12-31
 Authors@R: 
 	c(
 		person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 o Added vignette "3-dimensional objects".  
 o `extract()` is faster.  
 o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
+o Hopefully fixed some issues when liking to `rgrass` and `terra` noted by R Bivand and R Hijmans.  
 
 # fasterRaster 8.4.0.3 (2024-12-15)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# fasterRaster 8.4.0.5 (2025-02-05)
+# fasterRaster 8.4.0.5 (2025-02-17)
 o Added vignette "3-dimensional objects".  
 o `[` is faster.  
 o `%in%` and `match()` work when `faster(useDataTable = FALSE)` and `table` argument is a character.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # fasterRaster 8.4.0.4 (2024-12-XX)
 o Added vignette "3-dimensional objects".  
+o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
 
 # fasterRaster 8.4.0.3 (2024-12-15)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # fasterRaster 8.4.0.4 (2024-12-XX)
 o Added vignette "3-dimensional objects".  
+o `extract()` is faster.  
 o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
 
 # fasterRaster 8.4.0.3 (2024-12-15)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # fasterRaster 8.4.0.4 (2024-12-XX)
 o Added vignette "3-dimensional objects".  
+o `[` is faster.  
 o `extract()` is faster.  
 o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
-o Hopefully fixed some issues when liking to `rgrass` and `terra` noted by R Bivand and R Hijmans.  
+o Hopefully fixed some issues when linking to `rgrass` and `terra` documentation noted by R Bivand and R Hijmans.  
 
 # fasterRaster 8.4.0.3 (2024-12-15)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-# fasterRaster 8.4.0.4 (2024-12-XX)
+# fasterRaster 8.4.0.5 (2025-02-05)
 o Added vignette "3-dimensional objects".  
 o `[` is faster.  
+o `%in%` and `match()` work when `faster(useDataTable = FALSE)` and `table` argument is a character.  
 o `extract()` is faster.  
 o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
 o Hopefully fixed some issues when linking to `rgrass` and `terra` documentation noted by R Bivand and R Hijmans.  

--- a/R/convHull.r
+++ b/R/convHull.r
@@ -7,7 +7,7 @@
 #'
 #' @return A `GVector`.
 #'
-#' @seealso [terra::convHull()], [sf::st_convex_hull()], module `v.hull` in **GRASS**
+#' @seealso \code{link[terra]{convHull}}, \code{link[sf]{st_convex_hull}}, module `v.hull` in **GRASS** (see `grassHelp("v.hull")`)
 #'
 #' @example man/examples/ex_convHull.r
 #'
@@ -81,7 +81,7 @@ methods::setMethod(
 			# concatenate
 			args <- list(x = vects[[1L]])
 			if (length(vects) > 1L) args <- c(args, list(vects[2:length(vects)]))
-			out <- do.call("c", args)
+			out <- do.call("c", args = args)
 
 		}
 	

--- a/R/extract.r
+++ b/R/extract.r
@@ -724,7 +724,7 @@ methods::setMethod(
     }
 
     # # don't know why, but having this here obviates extraction of all NAs on first extract attempt
-    if (inherits(x, "GRaster")) x <- x + 0
+    # if (inherits(x, "GRaster")) x[[1L]] <- x[[1L]] + 0
 
     for (set in seq_len(sets)) {
 

--- a/R/fast.r
+++ b/R/fast.r
@@ -69,7 +69,7 @@
 #' * **Correction outside of *fasterRaster***: Before you convert the vector into **fasterRaster**'s `GVector` format, you can also try using the [terra::makeValid()] or [sf::st_make_valid()] tools to fix issues, then use `fast()`.
 #' * **Post-conversion to a `GVector`**: If you do get a vector loaded into `GVector` format, you can also use a set of **fasterRaster** vector-manipulation [tools][breakPolys] or [fillHoles()] to fix issues.
 #'
-#' @seealso [rgrass::read_RAST()] and [rgrass::read_VECT()], [vector cleaning][breakPolys], [fillHoles()], plus **GRASS** modules `v.in.ogr` (see `grassHelp("v.in.ogr")`) and `r.import` (see `grassHelp("r.import")`)
+#' @seealso \code{\link[rgrass]{read_RAST}} and \code{\link[rgrass]{read_VECT}}, [vector cleaning][breakPolys], [fillHoles()], plus **GRASS** modules `v.in.ogr` (see `grassHelp("v.in.ogr")`) and `r.import` (`grassHelp("r.import")`)
 #'
 #' @returns A `GRaster` or `GVector`.
 #'

--- a/R/match.r
+++ b/R/match.r
@@ -42,11 +42,18 @@ methods::setMethod(
 	
 		if (is.character(table)) {
 
-			levs <- levels(x)[[i]]
+			levs <- cats(x)[[i]]
 			ac <- activeCat(x)[i]
-			labels <- levs[[ac + 1L]]
-			matches <- match(table, labels)
-			vals <- levs[[1L]][matches]
+
+			if (faster("useDataTable")) {
+				labels <- levs[[ac + 1L]]
+				matches <- match(table, labels)
+				vals <- levs[[1L]][matches]
+			} else {
+				labels <- levs[ , ac + 1L, drop = TRUE]
+				matches <- match(table, labels)
+				vals <- levs[ , 1L, drop = TRUE][matches]
+			}
 
 		} else {
 			vals <- table
@@ -159,11 +166,22 @@ methods::setMethod(
 	
 		if (is.character(table)) {
 
-			levs <- levels(x)[[i]]
+			levs <- cats(x)[[i]]
 			ac <- activeCat(x)[i]
-			labels <- levs[[ac + 1L]]
-			matches <- match(table, labels)
-			vals <- levs[[1L]][matches]
+
+			# labels <- levs[[ac + 1L]]
+			# matches <- match(table, labels)
+			# vals <- levs[[1L]][matches]
+
+			if (faster("useDataTable")) {
+				labels <- levs[[ac + 1L]]
+				matches <- match(table, labels)
+				vals <- levs[[1L]][matches]
+			} else {
+				labels <- levs[ , ac + 1L, drop = TRUE]
+				matches <- match(table, labels)
+				vals <- levs[ , 1L, drop = TRUE][matches]
+			}
 
 		} else {
 			vals <- table

--- a/R/project.r
+++ b/R/project.r
@@ -204,7 +204,7 @@ methods::setMethod(
 			xRast <- fast(xRast)
 
 			# resample x in its native location to the resolution it will have in the target location
-			x <- resample(
+			x <- .resample(
 				x = x,
 				y = xRast,
 				method = method,

--- a/R/quiet.r
+++ b/R/quiet.r
@@ -10,7 +10,7 @@
 .quiet <- function() {
 
 	if (faster("debug")) {
-		out <- NULL
+		out <- 'verbose'
 	} else {
 		out <- "quiet"
 	}

--- a/R/resample.r
+++ b/R/resample.r
@@ -62,7 +62,7 @@ methods::setMethod(
 		} else {
 			tbres <- t <- b <- NA_real_
 		}
-		
+### NEED TO EXTENT TO ENCOMPASS x IF ITS EXTENT IS OUTSIDE THIS		
 		w <- W(y)
 		e <- E(y)
 		s <- S(y)
@@ -114,9 +114,9 @@ methods::setMethod(
 		ewres = ewres, nsres = nsres,
 		flags = c("o", .quiet())
 	)
-	if (!is.na(t)) args <- c(args, t=t)
-	if (!is.na(b)) args <- c(args, t=b)
-	if (!is.na(tbres)) args <- c(args, tbres=tbres)
+	if (!is.na(t)) args <- c(args, t = t)
+	if (!is.na(b)) args <- c(args, t = b)
+	if (!is.na(tbres)) args <- c(args, tbres = tbres)
 
 	do.call(rgrass::execGRASS, args=args)
 	

--- a/R/spatSample.r
+++ b/R/spatSample.r
@@ -298,7 +298,6 @@ methods::setMethod(
 		# 	flags = c(.quiet(), "overwrite")
 		# )
 
-		if (faster("verbose")) omnibus::say("Extracting values...")
 		vals <- .extractFromRasterAtPoints(x = x, y = src, cats = cats, verbose = verbose)
 
 		if (exists("out", inherits = FALSE)) {

--- a/R/spatSample.r
+++ b/R/spatSample.r
@@ -61,7 +61,7 @@ methods::setMethod(
 		byStratum <- FALSE
 		zlim <- NULL
 		seed <- NULL
-		verbose <- FALSE
+		verbose <- TRUE
 	
 	}
 
@@ -270,7 +270,7 @@ methods::setMethod(
 	} else {
 		
 		if (verbose | faster("verbose")) omnibus::say("Placing points...")
-		src <- .makeSourceName("spatSample", "vector")
+		src <- .makeSourceName("spatSample_v_random", "vector")
 		args <- list(
 			cmd = "v.random",
 			output = src,
@@ -298,7 +298,7 @@ methods::setMethod(
 		# 	flags = c(.quiet(), "overwrite")
 		# )
 
-		vals <- .extractFromRasterAtPoints(x = x, y = src, cats = cats, verbose = verbose)
+		vals <- .extractFromRasterAtPoints(x = x, y = src, xNames = names(x), dtype = datatype(x), levels = levels(x), cats = cats, verbose = verbose)
 
 		if (exists("out", inherits = FALSE)) {
 			out <- cbind(out, vals)

--- a/R/subset_single_bracket.r
+++ b/R/subset_single_bracket.r
@@ -179,7 +179,7 @@ methods::setMethod(
 				db <- data.table::data.table(cat = cats, qid = qid)
 				.vAttachDatabase(x, db, cats = cats)
 
-				args$where <- "qid = 1" # will not work with inequalities
+				args$where <- "qid = 1" # will not work with inequalities!
 
 			} else if (gtype %in% c("area", "line")) {
 			
@@ -290,7 +290,8 @@ methods::setMethod(
 			out <- NULL
 		} else {
 			# out <- .makeGVector(src, table = table, cats = newCats)
-			out <- .makeGVector(src, table = table)
+			# out <- .makeGVector(src, table = table)
+			out <- .makeGVector(src, table = table, cats = keepCats)
 		}
 
 	}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- badges: end -->
 Faster raster processing in `R` using `GRASS GIS`
  
-<a href="https://adamlilith.github.io/fasterRaster/"><img src="man/figures/logo.png" align="right" height="232" alt="fasterRaster website" /></a>
+<a href="https://github.com/adamlilith/enmSdmX"><img src="man/figures/logo.png" align="right" height="130" alt="enmSdmX website" /></a>
 
 `fasterRaster` is an **R** package designed specifically to handle large-in-memory/large-on-disk spatial rasters and vectors. `fasterRaster` does this using Open Source Geospatial's <a href="https://grass.osgeo.org/">`GRASS GIS`</a>
 

--- a/README.md
+++ b/README.md
@@ -189,11 +189,8 @@ Note that the `M1.M2` and `S1.S2` increment independently. For example, if the v
 * The Wiki on [how to run `GRASS` in `R` or `R` in `GRASS`](https://grasswiki.osgeo.org/wiki/R_statistics/rgrass) will help you to become a power-user of `GRASS` in `R`.
 
 # Citation
-A publication is forthcoming(!), but as of February 2024, there is not as of yet a package-specific citation for **fasterRaster**. However, the package was first used in:
+A publication is forthcoming! In the meantime, please cite:
 
-Morelli*, T.L., Smith*, A.B., Mancini, A.N., Balko, E. A., Borgenson, C., Dolch,R., Farris, Z., Federman, S., Golden, C.D., Holmes, S., Irwin, M., Jacobs,R.L., Johnson, S., King, T., Lehman, S., Louis, E.E. Jr., Murphy, A.,Randriahaingo, H.N.T., Lucien,Randriannarimanana, H.L.L.,Ratsimbazafy, J.,Razafindratsima, O.H., and Baden, A.L. 2020. The fate of Madagascar’s rainforest habitat.  *Nature Climate Change* 10:89-96. * Equal contribution DOI: <a href="https://doi.org/10.1038/s41558-019-0647-x">https://doi.org/10.1038/s41558-019-0647-x</a>.
-
-*Abstract*. Madagascar has experienced extensive deforestation and overharvesting, and anthropogenic climate change will compound these pressures. Anticipating these threats to endangered species and their ecosystems requires considering both climate change and habitat loss effects. The genus *Varecia* (ruffed lemurs), which is composed of two Critically Endangered forest-obligate species, can serve as a status indicator of the biodiversity eastern rainforests of Madagascar. Here, we combined decades of research to show that the suitable habitat for ruffed lemurs could be reduced by 29–59% from deforestation, 14–75% from climate change (representative concentration pathway 8.5) or 38–93% from both by 2070. If current protected areas avoid further deforestation, climate change will still reduce the suitable habitat by 62% (range: 38–83%). If ongoing deforestation continues, the suitable habitat will decline by 81% (range: 66–93%). Maintaining and enhancing the integrity of protected areas, where rates of forest loss are lower, will be essential for ensuring persistence of the diversity of the rapidly diminishing Malagasy rainforests.
-
+Smith, A.B. 2024. `fasterRaster`: Faster raster processing in `R` using `GRASS GIS`. URL: https://cran.r-project.org/package=fasterRaster.
 
 ~ Adam

--- a/inst/pkgdown.yml
+++ b/inst/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: 3.1.11
+pandoc: 3.6.2
 pkgdown: 2.1.1
 pkgdown_sha: ~
 articles:
@@ -10,7 +10,7 @@ articles:
   projects_mapsets: projects_mapsets.html
   regions: regions.html
   three_d_objects: three_d_objects.html
-last_built: 2025-02-05T19:23Z
+last_built: 2025-02-18T04:46Z
 urls:
   reference: https://github.com/adamlilith/fasterRaster/reference
   article: https://github.com/adamlilith/fasterRaster/articles

--- a/inst/pkgdown.yml
+++ b/inst/pkgdown.yml
@@ -10,7 +10,7 @@ articles:
   projects_mapsets: projects_mapsets.html
   regions: regions.html
   three_d_objects: three_d_objects.html
-last_built: 2024-12-16T23:25Z
+last_built: 2025-02-05T19:23Z
 urls:
   reference: https://github.com/adamlilith/fasterRaster/reference
   article: https://github.com/adamlilith/fasterRaster/articles

--- a/man/convHull.Rd
+++ b/man/convHull.Rd
@@ -48,5 +48,5 @@ for (i in 1:n) {
 }
 }
 \seealso{
-\code{\link[terra:convhull]{terra::convHull()}}, \code{\link[sf:geos_unary]{sf::st_convex_hull()}}, module \code{v.hull} in \strong{GRASS}
+\code{link[terra]{convHull}}, \code{link[sf]{st_convex_hull}}, module \code{v.hull} in \strong{GRASS} (see \code{grassHelp("v.hull")})
 }

--- a/man/fast.Rd
+++ b/man/fast.Rd
@@ -229,5 +229,5 @@ mat <- fast(mat, crs = "epsg:4326", keepgeom = TRUE) # WGS84
 }
 }
 \seealso{
-\code{\link[rgrass:readRAST]{rgrass::read_RAST()}} and \code{\link[rgrass:readVECT]{rgrass::read_VECT()}}, \link[=breakPolys]{vector cleaning}, \code{\link[=fillHoles]{fillHoles()}}, plus \strong{GRASS} modules \code{v.in.ogr} (see \code{grassHelp("v.in.ogr")}) and \code{r.import} (see \code{grassHelp("r.import")})
+\code{\link[rgrass]{read_RAST}} and \code{\link[rgrass]{read_VECT}}, \link[=breakPolys]{vector cleaning}, \code{\link[=fillHoles]{fillHoles()}}, plus \strong{GRASS} modules \code{v.in.ogr} (see \code{grassHelp("v.in.ogr")}) and \code{r.import} (\code{grassHelp("r.import")})
 }


### PR DESCRIPTION
`fasterRaster` 8.4.0.5 (2025-02-17)
o Added vignette "3-dimensional objects".  
o `[` is faster.  
o `%in%` and `match()` work when `faster(useDataTable = FALSE)` and `table` argument is a character.  
o `extract()` is faster.  
o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
o Hopefully fixed some issues when linking to `rgrass` and `terra` documentation noted by R Bivand and R Hijmans.  
