### PR TITLE
fasterRaster 8.4.0.5 (2025-02-25)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: fasterRaster
 Type: Package
 Title: Faster Raster and Spatial Vector Processing Using 'GRASS GIS'
 Version: 8.4.0.5
-Date: 2025-02-17
+Date: 2025-02-25
 Authors@R: 
 	c(
 		person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ o Added vignette "3-dimensional objects".
 o `[` is faster.  
 o `%in%` and `match()` work when `faster(useDataTable = FALSE)` and `table` argument is a character.  
 o `extract()` is faster.  
+o `fast()` has better error catching for vectors.  
 o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
 o Hopefully fixed some issues when linking to `rgrass` and `terra` documentation noted by R Bivand and R Hijmans.  
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
-# fasterRaster 8.4.0.5 (2025-02-17)
+# fasterRaster 8.4.0.5 (2025-02-25)
 o Added vignette "3-dimensional objects".  
 o `[` is faster.  
 o `%in%` and `match()` work when `faster(useDataTable = FALSE)` and `table` argument is a character.  
 o `extract()` is faster.  
 o `fast()` has better error catching for vectors.  
 o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
-o Hopefully fixed some issues when linking to `rgrass` and `terra` documentation noted by R Bivand and R Hijmans.  
+o Fixes issues when linking to `rgrass` and `terra` documentation noted by R Bivand and R Hijmans.  
 
 # fasterRaster 8.4.0.3 (2024-12-15)
 

--- a/R/buffer.r
+++ b/R/buffer.r
@@ -16,8 +16,13 @@
 #' 
 #' @param unit Character: Rasters -- Indicates the units of \code{width}. Can be one of:
 #'
-#' 	* `"cells"`: Units are numbers of cells.
-#'	* `"meters"` (default), `"metres"`, or `"m"`; `"kilometers"` or `"km"`; `"feet"` or `"ft"`; `"miles"` or `"mi"`; `"nautical miles"` or `"nmi"`.
+#' * `"cells"`: Units are numbers of cells.
+#' * `"meters"` (default), `"metres"`, or `"m"`
+#' * `"kilometers"` or `"km"`
+#' * `"feet"` or `"ft"`
+#' * `"miles"` or `"mi"`
+#' * `"nautical miles"` or `"nmi"`
+#'
 #' Partial matching is used and case is ignored.
 #'
 #' @param method Character: Rasters -- Only used if `units` is `"cells"`. Indicates the manner in which distances are calculated for adding of cells:
@@ -27,7 +32,7 @@
 #'
 #' Partial matching is used and case is ignored.
 #'
-#' @param lowMemory Logical: Rasters -- Only used if buffering a raster and `units` is not `"meters"`. If `FALSE` (default) use faster, memory-intensive procedure. If `TRUE` then use the slower, low-memory version. To help decide which to use, consider using the low-memory version on a system with 1 GB of RAM for a raster larger than about 32000x32000 cells, or for a system with  with 8 GB of RAM a raster larger than about 90000x90000 cells.
+#' @param lowMemory Logical: Rasters -- Only used if buffering a raster and `units` is not `"meters"`. If `FALSE` (default) use faster, memory-intensive procedure. If `TRUE` then use the slower, low-memory version. To help decide which to use, consider using the low-memory version on a system with 1 GB of RAM for a raster larger than about 32000 x 32000 cells, or for a system with  with 8 GB of RAM a raster larger than about 90000 x 90000 cells.
 #'
 #' @param capstyle,endCapStyle Character: Vectors -- Style for ending the "cap" of buffers around lines. Valid options include `"rounded"`, `"square"`, and "`flat`".
 #'
@@ -74,7 +79,7 @@ methods::setMethod(
 		
 			methods <- c("euclidean", "manhattan", "maximum")
 			method <- tolower(method)
-			method <- omnibus::pmatchSafe(method, method)
+			method <- omnibus::pmatchSafe(method, method, nmax = 1L)
 
 			args <- list(
 				cmd = "r.grow",
@@ -90,14 +95,8 @@ methods::setMethod(
 		### buffering by distance
 		} else {
 		
-			if (lowMemory) {
-				fx <- "r.buffer.lowmem"
-			} else {
-				fx <- "r.buffer"
-			}
-
 			args <- list(
-				cmd = ifelse (lowMemory, "r.buffer.lowmem", "r.buffer"),
+				cmd = ifelse(lowMemory, "r.buffer.lowmem", "r.buffer"),
 				input = sources(x)[i],
 				output = srcBuffer,
 				distances = width,

--- a/R/fast.r
+++ b/R/fast.r
@@ -97,6 +97,23 @@ methods::setMethod(
 		...
 	) {
 
+	### debugging
+	if (FALSE) {
+	
+		rastOrVect <- NULL
+		levels <- TRUE
+		extent <- NULL
+		correct <- TRUE
+		snap <- NULL
+		area <- NULL
+		steps <- 10
+		dropTable <- FALSE
+		resolve <- NA
+		verbose <- TRUE
+		dots <- list()
+	
+	}
+
 	if (is.na(faster("grassDir"))) stop("You must specify the folder in which GRASS is installed using faster().")
 
 	### dots
@@ -326,7 +343,7 @@ methods::setMethod(
 						output = src,
 						snap = thisSnap,
 						min_area = thisArea,
-						flags = c(.quiet(), "verbose", "overwrite", "t", correctTopoFlag),
+						flags = c("verbose", "overwrite", "t", "o", correctTopoFlag),
 						ignore.stderr = FALSE,
 						Sys_show.output.on.console = FALSE,
 						echoCmd = FALSE, # displays GRASS command
@@ -336,7 +353,8 @@ methods::setMethod(
 
 				valid <- !any(c(
 					grepl(run, pattern = "WARNING: The output contains topological errors"),
-					grepl(run, pattern = "Invalid argument")
+					grepl(run, pattern = "Invalid argument"),
+					run == "1"
 				))
 
 				if (valid) { # more thorough test... slower
@@ -456,10 +474,15 @@ methods::setMethod(
 							flags = c(.quiet(), "overwrite", "t", correctTopoFlag)
 						)
 						
-						info <- .vectInfo(src)
-						valid <- .validVector(info, table)
+						made <- .exists(src)
+						if (made) {
+							info <- .vectInfo(src)
+							valid <- .validVector(info, table)
+						} else {
+							valid <- FALSE
+						}
 
-						if (!valid & !is.na(resolve)) {
+						if (made & !valid & !is.na(resolve)) {
 
 							table <- NULL
 							src <- .aggDisaggVect(src, resolve = resolve, verbose = verbose)
@@ -470,10 +493,12 @@ methods::setMethod(
 
 						}
 
-						if (!valid & verbose & !dropTable) {
+						if (made & !valid & verbose & !dropTable) {
 							omnibus::say("   Vector has ", info$nGeometries, " valid geometries, ", sum(is.na(info$cats)), " invalid geometries, and ", nrow(table), " rows in its data table.")
-						} else if (!valid & verbose) {
+						} else if (made & !valid & verbose) {
 							omnibus::say("   Vector has ", info$nGeometries, " valid geometries and ", sum(is.na(info$cats)), " invalid geometries.")
+						} else if (!made) {
+							omnibus::say("   Failed to create vector.")
 						}
 
 						step <- step + 1L
@@ -506,10 +531,16 @@ methods::setMethod(
 							flags = c(.quiet(), "overwrite", "t", correctTopoFlag)
 						)
 						
-						info <- .vectInfo(src)
-						valid <- .validVector(info, table)
+						made <- .exists(src)
 
-						if (!valid & !is.na(resolve)) {
+						if (made) {
+							info <- .vectInfo(src)
+							valid <- .validVector(info, table)
+						} else {
+							valid <- FALSE
+						}
+
+						if (made & !valid & !is.na(resolve)) {
 
 							table <- NULL
 							src <- .aggDisaggVect(src, resolve = resolve, verbose = verbose)
@@ -520,10 +551,12 @@ methods::setMethod(
 
 						}
 
-						if (!valid & verbose & !dropTable) {
+						if (made & !valid & verbose & !dropTable) {
 							omnibus::say("   Vector has ", info$nGeometries, " valid geometries, ", sum(is.na(info$cats)), " invalid geometries, and ", nrow(table), " rows in its data table.")
-						} else if (!valid & verbose) {
+						} else if (made & !valid & verbose) {
 							omnibus::say("   Vector has ", info$nGeometries, " valid geometries and ", sum(is.na(info$cats)), " invalid geometries.")
+						} else if (!made) {
+							omnibus::say("   Failed to create vector.")
 						}
 						step <- step + 1L
 
@@ -559,12 +592,16 @@ methods::setMethod(
 							flags = c(.quiet(), "overwrite", "t", correctTopoFlag)
 						)
 						
-						if (!exists("table", inherits = TRUE)) table <- .vAsDataTable(src)
+						made <- .exists(src)
+						if (made) {
+							info <- .vectInfo(src)
+							valid <- .validVector(info, table)
+							if (!exists("table", inherits = TRUE)) table <- .vAsDataTable(src)
+						} else {
+							valid <- FALSE
+						}
 
-						info <- .vectInfo(src)
-						valid <- .validVector(info, table)
-
-						if (!valid & !is.na(resolve)) {
+						if (made & !valid & !is.na(resolve)) {
 
 							table <- NULL
 							src <- .aggDisaggVect(src, resolve = resolve, verbose = verbose)
@@ -575,10 +612,12 @@ methods::setMethod(
 
 						}
 
-						if (!valid & verbose & !dropTable) {
+						if (made & !valid & verbose & !dropTable) {
 							omnibus::say("   Vector has ", info$nGeometries, " valid geometries, ", sum(is.na(info$cats)), " invalid geometries, and ", nrow(table), " rows in its data table.")
-						} else if (!valid & verbose) {
+						} else if (made & !valid & verbose) {
 							omnibus::say("   Vector has ", info$nGeometries, " valid geometries and ", sum(is.na(info$cats)), " invalid geometries.")
+						} else if (!made) {
+							omnibus::say("   Failed to create vector.")
 						}
 						step <- step + 1L
 

--- a/inst/pkgdown.yml
+++ b/inst/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: 3.6.2
+pandoc: 3.1.11
 pkgdown: 2.1.1
 pkgdown_sha: ~
 articles:
@@ -10,7 +10,7 @@ articles:
   projects_mapsets: projects_mapsets.html
   regions: regions.html
   three_d_objects: three_d_objects.html
-last_built: 2025-02-18T04:46Z
+last_built: 2025-02-25T18:57Z
 urls:
   reference: https://github.com/adamlilith/fasterRaster/reference
   article: https://github.com/adamlilith/fasterRaster/articles

--- a/man/buffer.Rd
+++ b/man/buffer.Rd
@@ -29,13 +29,16 @@
 For vectors, distance from the object to place the buffer. Negative values create "inside" buffers. Units are in the same units as the current coordinate reference system (e.g., degrees for WGS84 or NAD83, often meters for projected systems).}
 
 \item{unit}{Character: Rasters -- Indicates the units of \code{width}. Can be one of:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{* `"cells"`: Units are numbers of cells.
-}\if{html}{\out{</div>}}
 \itemize{
-\item \code{"meters"} (default), \code{"metres"}, or \code{"m"}; \code{"kilometers"} or \code{"km"}; \code{"feet"} or \code{"ft"}; \code{"miles"} or \code{"mi"}; \code{"nautical miles"} or \code{"nmi"}.
-Partial matching is used and case is ignored.
-}}
+\item \code{"cells"}: Units are numbers of cells.
+\item \code{"meters"} (default), \code{"metres"}, or \code{"m"}
+\item \code{"kilometers"} or \code{"km"}
+\item \code{"feet"} or \code{"ft"}
+\item \code{"miles"} or \code{"mi"}
+\item \code{"nautical miles"} or \code{"nmi"}
+}
+
+Partial matching is used and case is ignored.}
 
 \item{method}{Character: Rasters -- Only used if \code{units} is \code{"cells"}. Indicates the manner in which distances are calculated for adding of cells:
 \itemize{
@@ -48,7 +51,7 @@ Partial matching is used and case is ignored.}
 
 \item{background}{Numeric: Rasters -- Value to assign to cells that are not \code{NA} and not part of the buffer (default is 0).}
 
-\item{lowMemory}{Logical: Rasters -- Only used if buffering a raster and \code{units} is not \code{"meters"}. If \code{FALSE} (default) use faster, memory-intensive procedure. If \code{TRUE} then use the slower, low-memory version. To help decide which to use, consider using the low-memory version on a system with 1 GB of RAM for a raster larger than about 32000x32000 cells, or for a system with  with 8 GB of RAM a raster larger than about 90000x90000 cells.}
+\item{lowMemory}{Logical: Rasters -- Only used if buffering a raster and \code{units} is not \code{"meters"}. If \code{FALSE} (default) use faster, memory-intensive procedure. If \code{TRUE} then use the slower, low-memory version. To help decide which to use, consider using the low-memory version on a system with 1 GB of RAM for a raster larger than about 32000 x 32000 cells, or for a system with  with 8 GB of RAM a raster larger than about 90000 x 90000 cells.}
 
 \item{capstyle, endCapStyle}{Character: Vectors -- Style for ending the "cap" of buffers around lines. Valid options include \code{"rounded"}, \code{"square"}, and "\code{flat}".}
 


### PR DESCRIPTION
**fasterRaster** 8.4.0.5 (2025-02-25)
o Added vignette "3-dimensional objects".  
o `[` is faster.  
o `%in%` and `match()` work when `faster(useDataTable = FALSE)` and `table` argument is a character.  
o `extract()` is faster.  
o `fast()` has better error catching for vectors.  
o `spatSample()` is faster when `values` or `cats` is `TRUE`.  
o Fixes issues when linking to `rgrass` and `terra` documentation noted by R Bivand and R Hijmans.  
