### PR TITLE
fasterRaster 8.4.0.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fasterRaster
 Type: Package
 Title: Faster Raster and Spatial Vector Processing Using 'GRASS GIS'
-Version: 8.4.0.5
-Date: 2025-02-25
+Version: 8.4.0.6
+Date: 2025-03-26
 Authors@R: 
 	c(
 		person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# fasterRaster 8.4.0.6 (2025-03-26)
+o `faster(debug = TRUE)` displays the **GRASS** command for each **GRASS** module called in a **fasterRaster** function.  
+o `GVector[i]` works for cases with long `i`s.  
+o Fixes to help pages.  
+
 # fasterRaster 8.4.0.5 (2025-02-25)
 o Added vignette "3-dimensional objects".  
 o `[` is faster.  

--- a/R/03_options.r
+++ b/R/03_options.r
@@ -185,6 +185,7 @@ faster <- function(
 
 	if (any(names(opts) %in% "debug")) {
 		info <- rgrass::set.echoCmdOption(.fasterRaster$options$debug)
+		info <- rgrass::set.echoCmdOption(value = .fasterRaster$options$debug)
 	}
 
 	invisible(out)

--- a/R/dim.r
+++ b/R/dim.r
@@ -37,6 +37,17 @@ methods::setMethod(
 	} # EOF
 )
 
+
+## Error on install: "the method for function 'dim' and signature x="missing" is sealed and cannot be re-defined"
+# #' @aliases dim
+# #' @rdname dim
+# #' @exportMethod dim
+# methods::setMethod(
+	# f = "dim",
+	# signature = "missing",
+	# definition = function(x) .region()@dimensions[1L:2L]
+# )
+
 #' @aliases dim3d
 #' @rdname dim
 #' @exportMethod dim3d

--- a/R/extract.r
+++ b/R/extract.r
@@ -689,7 +689,7 @@ methods::setMethod(
     dtype = NULL,
     levels = NULL,
     cats = TRUE,
-    verbose = TRUE
+    verbose = FALSE
 ) {
 
     if (inherits(x, "GRaster")) {

--- a/R/mow.r
+++ b/R/mow.r
@@ -4,10 +4,10 @@
 #'
 #' Calling this function inside another function's environment and defining `x` as `"*"` can be very **dangerous**, as it will detect objects outside of that environment, and thus delete any rasters/vectors outside that environment. Here is a guide:
 #' * To delete files associated with a single `GRaster` or `GVector`, use `mow(GRaster_to_unlink)` or `mow(GVector_to_unlink)`.
-# * To delete files associated with more than one `GRaster`s and/or `GVector`s, provide them as a list. For example, use `mow(list(GRaster_to_unlink, GVector_to_unlink))`.
-#' To remove all rasters, all vectors, or all rasters and vectors in the **GRASS** cache that are not linked to a `GRaster` or `GVector`, use `mow("*")`.
-#' To remove all rasters or all vectors in the **GRASS** cache, use `mow("*", type = "rasters")` or `mow("*", type = "vectors")`.
-#' To remove all rasters or all vectors in the **GRASS** cache *except* for certain ones, use `mow("*", unlinked = FALSE, keep = list(GRaster_to_keep, GVector_to_keep))`. You can combine this with the `keep` argument to retain specific rasters or vectors. For example, you can use `mow("*", unlinked = FALSE, type = "rasters", keep = list(GRaster_to_keep))`.
+#' * To delete files associated with more than one `GRaster`s and/or `GVector`s, provide them as a list. For example, use `mow(list(GRaster_to_unlink, GVector_to_unlink))`.
+#' * To remove all rasters, all vectors, or all rasters and vectors in the **GRASS** cache that are not linked to a `GRaster` or `GVector`, use `mow("*")`.
+#' * To remove all rasters or all vectors in the **GRASS** cache, use `mow("*", type = "rasters")` or `mow("*", type = "vectors")`.
+#' * To remove all rasters or all vectors in the **GRASS** cache *except* for certain ones, use `mow("*", keep = list(GRaster_to_keep, GVector_to_keep))`. You can combine this with the `keep` argument to retain specific rasters or vectors. For example, you can use `mow("*", type = "rasters", keep = list(GRaster_to_keep))`.
 #'
 #' @param x Any of:
 #' * `"unlinked"` (default): Delete **GRASS** rasters and/or vectors that are unlinked to `GRaster`s or `GVector`s in the environment in which the function was called, or the environment named in `pos`.

--- a/R/subset_single_bracket.r
+++ b/R/subset_single_bracket.r
@@ -190,7 +190,8 @@ methods::setMethod(
 			}
 
 			do.call(rgrass::execGRASS, args = args)
-			src <- .vRecat(src, gtype = gtype, cats = keepCats)
+			# src <- .vRecat(src, gtype = gtype, cats = keepCats) # using cats argument removes some point geometries!!!
+			src <- .vRecat(src, gtype = gtype) # retains all point geometries
 
 # 				srcs <- character()
 # 				trim <- TRUE

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 <!-- badges: end -->
 Faster raster processing in `R` using `GRASS GIS`
- 
-<a href="https://github.com/adamlilith/enmSdmX"><img src="man/figures/logo.png" align="right" height="130" alt="enmSdmX website" /></a>
+
+<a href="https://github.com/adamlilith/fasterRaster"><img src="man/figures/logo.png" align="right" height="130" alt="fasterRaster website" /></a>
 
 `fasterRaster` is an **R** package designed specifically to handle large-in-memory/large-on-disk spatial rasters and vectors. `fasterRaster` does this using Open Source Geospatial's <a href="https://grass.osgeo.org/">`GRASS GIS`</a>
 

--- a/man/mow.Rd
+++ b/man/mow.Rd
@@ -41,9 +41,10 @@ Invisibly returns a named vector with the number of rasters and vectors deleted.
 Calling this function inside another function's environment and defining \code{x} as \code{"*"} can be very \strong{dangerous}, as it will detect objects outside of that environment, and thus delete any rasters/vectors outside that environment. Here is a guide:
 \itemize{
 \item To delete files associated with a single \code{GRaster} or \code{GVector}, use \code{mow(GRaster_to_unlink)} or \code{mow(GVector_to_unlink)}.
-To remove all rasters, all vectors, or all rasters and vectors in the \strong{GRASS} cache that are not linked to a \code{GRaster} or \code{GVector}, use \code{mow("*")}.
-To remove all rasters or all vectors in the \strong{GRASS} cache, use \code{mow("*", type = "rasters")} or \code{mow("*", type = "vectors")}.
-To remove all rasters or all vectors in the \strong{GRASS} cache \emph{except} for certain ones, use \code{mow("*", unlinked = FALSE, keep = list(GRaster_to_keep, GVector_to_keep))}. You can combine this with the \code{keep} argument to retain specific rasters or vectors. For example, you can use \code{mow("*", unlinked = FALSE, type = "rasters", keep = list(GRaster_to_keep))}.
+\item To delete files associated with more than one \code{GRaster}s and/or \code{GVector}s, provide them as a list. For example, use \code{mow(list(GRaster_to_unlink, GVector_to_unlink))}.
+\item To remove all rasters, all vectors, or all rasters and vectors in the \strong{GRASS} cache that are not linked to a \code{GRaster} or \code{GVector}, use \code{mow("*")}.
+\item To remove all rasters or all vectors in the \strong{GRASS} cache, use \code{mow("*", type = "rasters")} or \code{mow("*", type = "vectors")}.
+\item To remove all rasters or all vectors in the \strong{GRASS} cache \emph{except} for certain ones, use \code{mow("*", keep = list(GRaster_to_keep, GVector_to_keep))}. You can combine this with the \code{keep} argument to retain specific rasters or vectors. For example, you can use \code{mow("*", type = "rasters", keep = list(GRaster_to_keep))}.
 }
 }
 \examples{


### PR DESCRIPTION
# fasterRaster 8.4.0.6 (2025-03-26)
o `faster(debug = TRUE)` displays the **GRASS** command for each **GRASS** module called in a **fasterRaster** function.  
o `GVector[i]` works for cases with long `i`s.  
o Fixes to help pages.  
